### PR TITLE
Fix Test Format navigation link in navbar

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -33,7 +33,7 @@
                             What is PTE
                         </a>
                     </li>
-                    <li><a href="/pages/pte-test.html">Test Format</a></li>
+                    <li><a href="/index.html#prep-section">Test Format</a></li>
                     <li><a href="/pages/pte-test.html">Scoring System</a></li>
                     <li><a href="/pages/pte-test.html">Test Centers</a></li>
                 </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ptet-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixed broken navbar link for Test Format.

Issue:
- Clicking "Test Format" redirected to /pages/pte-test.html which does not exist, causing 404 error.

Fix:
- Updated link to point to correct section in index.html (#prep-section)

Result:
- Users can now directly navigate to the Test Format section without 404 error.