### PR TITLE
feat(backend): [Task 42] Add study materials model and schema documentation

### DIFF
--- a/back-end/src/docs/study-materials-schema.md
+++ b/back-end/src/docs/study-materials-schema.md
@@ -1,0 +1,35 @@
+# Study Materials Schema
+
+## Table Name
+
+study_materials
+
+## Fields
+
+| Field | Type | Description |
+|---------|---------|---------|
+| id | UUID | Unique identifier |
+| title | STRING | Study material title |
+| description | TEXT | Material description |
+| type | ENUM | article, video, tip |
+| skill | ENUM | speaking, writing, reading, listening |
+| content_url | TEXT | URL to resource |
+| is_premium | BOOLEAN | Premium access flag |
+| created_at | DATE | Record creation timestamp |
+
+## Purpose
+
+Stores study resources available to users for PTE preparation.
+
+## Supported Types
+
+- article
+- video
+- tip
+
+## Supported Skills
+
+- speaking
+- writing
+- reading
+- listening

--- a/back-end/src/models/StudyMaterial.js
+++ b/back-end/src/models/StudyMaterial.js
@@ -1,0 +1,62 @@
+const { DataTypes } = require("sequelize");
+
+module.exports = (sequelize) => {
+  const StudyMaterial = sequelize.define(
+    "StudyMaterial",
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+
+      type: {
+        type: DataTypes.ENUM("article", "video", "tip"),
+        allowNull: false,
+      },
+
+      skill: {
+        type: DataTypes.ENUM(
+          "speaking",
+          "writing",
+          "reading",
+          "listening"
+        ),
+        allowNull: false,
+      },
+
+      content_url: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+
+      is_premium: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+
+      created_at: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: "study_materials",
+      timestamps: false,
+    }
+  );
+
+  return StudyMaterial;
+};


### PR DESCRIPTION
## Task Completed

Implements Task 42: Design `study_materials` table.

### Changes Made

* Added `StudyMaterial` Sequelize model
* Added all required fields:

  * `id`
  * `title`
  * `description`
  * `type`
  * `skill`
  * `content_url`
  * `is_premium`
  * `created_at`
* Added enum constraints for:

  * `article`, `video`, `tip`
  * `speaking`, `writing`, `reading`, `listening`
* Added schema documentation in `study-materials-schema.md`

### Files Added

* `back-end/src/models/StudyMaterial.js`
* `back-end/src/docs/study-materials-schema.md`

### Notes

This PR focuses only on the database schema/model design required for Task 42. No API endpoints were introduced as endpoint implementation is covered in later tasks.

Related to #72 

