### PR TITLE
Restored/pte test theme

### DIFF
--- a/pages/partners.html
+++ b/pages/partners.html
@@ -1,210 +1,450 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Partners & Research | PTE HUB</title>
 
-    <link rel="stylesheet" href="../styles/css/style.css">
-    <link rel="stylesheet" href="../styles/css/navbar.css">
-    <link rel="stylesheet" href="../styles/css/footer.css">
-    <link rel="stylesheet" href="../styles/css/partners.css">
-    <link rel="stylesheet" href="../styles/css/auth-popup.css">
+    <!-- Global Styles -->
+    <link rel="stylesheet" href="../styles/css/style.css" />
+    <link rel="stylesheet" href="../styles/css/navbar.css" />
+    <link rel="stylesheet" href="../styles/css/footer.css" />
+    <link rel="stylesheet" href="../styles/css/auth-popup.css" />
+    <link rel="stylesheet" href="../styles/css/theme.css" />
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+
+    <!-- Theme initialisation -->
+    <script src="../scripts/js/theme.js"></script>
+
+    <style>
+        /* ===== HERO ===== */
+        .partners-hero {
+            position: relative;
+            background-image: url('/assets/images/partner-bg.avif');
+            background-size: cover;
+            background-position: center 30%;
+            min-height: 75vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            color: white;
+        }
+        .partners-hero::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, rgba(0,0,0,0.65), rgba(141,33,35,0.75));
+            z-index: 1;
+        }
+        .partners-hero .hero-inner {
+            position: relative;
+            z-index: 2;
+            max-width: 800px;
+            padding: 0 20px;
+        }
+        .partners-hero h1 {
+            font-size: clamp(2.4rem, 5vw, 3.5rem);
+            font-weight: 700;
+            margin-bottom: 15px;
+            text-shadow: 0 2px 15px rgba(0,0,0,0.4);
+        }
+        .partners-hero p {
+            font-size: clamp(1rem, 2vw, 1.2rem);
+            color: rgba(255,255,255,0.95);
+            max-width: 700px;
+            margin: 0 auto;
+            text-shadow: 0 1px 6px rgba(0,0,0,0.3);
+        }
+        .partners-hero .hero-actions {
+            margin-top: 30px;
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+        .partners-hero .primary-btn,
+        .partners-hero .secondary-btn {
+            display: inline-block;
+            padding: 12px 28px;
+            border-radius: 8px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: all 0.3s ease;
+            border: none;
+            cursor: pointer;
+        }
+        .partners-hero .primary-btn {
+            background: white;
+            color: #8d2123;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+        }
+        .partners-hero .primary-btn:hover {
+            transform: translateY(-3px);
+            background: #f0f0f0;
+        }
+        .partners-hero .secondary-btn {
+            background: transparent;
+            color: white;
+            border: 2px solid white;
+        }
+        .partners-hero .secondary-btn:hover {
+            background: rgba(255,255,255,0.1);
+            transform: translateY(-3px);
+        }
+
+        /* ===== SECTION OVERRIDES (use global .features-section etc.) ===== */
+        .partners-section {
+            padding: clamp(56px, 8vw, 96px) 20px;
+        }
+        .partners-section .section-heading {
+            text-align: center;
+            margin-bottom: 50px;
+        }
+        .partners-section .section-heading h2 {
+            font-size: clamp(1.75rem, 4vw, 2.5rem);
+            color: var(--text-primary);
+        }
+        .partners-section .section-heading p {
+            color: var(--text-muted);
+            max-width: 700px;
+            margin: 10px auto 0;
+        }
+
+        /* ===== PARTNER LOGOS ===== */
+        .logo-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 25px;
+            margin-top: 30px;
+        }
+        .logo-box {
+            background: var(--bg-card);
+            border: 1px solid var(--border-card);
+            border-radius: 12px;
+            padding: 25px 15px;
+            text-align: center;
+            box-shadow: var(--shadow-soft);
+            transition: all 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+        }
+        .logo-box:hover {
+            transform: translateY(-4px);
+            box-shadow: var(--shadow-lift);
+            border-color: var(--accent);
+        }
+        .logo-box i {
+            font-size: 2.2rem;
+            color: var(--accent);
+        }
+        .logo-box span {
+            font-weight: 600;
+            color: var(--text-primary);
+            font-size: 0.95rem;
+        }
+
+        /* ===== PUBLICATIONS LIST ===== */
+        .pub-list {
+            max-width: 850px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+        .pub-item {
+            background: var(--bg-card);
+            border: 1px solid var(--border-card);
+            border-radius: 12px;
+            padding: 20px 25px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 20px;
+            transition: all 0.3s ease;
+            box-shadow: var(--shadow-soft);
+        }
+        .pub-item:hover {
+            transform: translateY(-3px);
+            box-shadow: var(--shadow-lift);
+        }
+        .pub-info {
+            display: flex;
+            align-items: flex-start;
+            gap: 16px;
+            flex: 1;
+        }
+        .pub-info i {
+            font-size: 2rem;
+            color: var(--accent);
+            margin-top: 4px;
+        }
+        .pub-info h4 {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin: 0 0 4px 0;
+        }
+        .pub-info p {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+            margin: 0;
+            line-height: 1.5;
+        }
+        .download-btn {
+            background: transparent;
+            border: 1.5px solid var(--accent);
+            color: var(--accent);
+            padding: 8px 16px;
+            border-radius: 8px;
+            font-weight: 700;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: all 0.25s ease;
+            white-space: nowrap;
+        }
+        .download-btn:hover {
+            background: var(--accent);
+            color: white;
+            box-shadow: 0 6px 15px rgba(141,33,35,0.2);
+        }
+
+        /* ===== FUTURE INITIATIVES ===== */
+        .future-card {
+            background: var(--bg-card);
+            border-radius: 16px;
+            padding: 40px;
+            box-shadow: var(--shadow-soft);
+            border: 1px solid var(--border-card);
+            max-width: 900px;
+            margin: 0 auto;
+            display: flex;
+            gap: 40px;
+            align-items: center;
+            transition: all 0.3s ease;
+        }
+        .future-card:hover {
+            box-shadow: var(--shadow-lift);
+        }
+        .future-text {
+            flex: 1.5;
+        }
+        .future-text h2 {
+            font-size: clamp(1.3rem, 2.5vw, 1.8rem);
+            color: var(--text-primary);
+            margin-bottom: 12px;
+        }
+        .future-text p {
+            color: var(--text-muted);
+            line-height: 1.7;
+        }
+        .future-text ul {
+            list-style: none;
+            padding: 0;
+            margin-top: 20px;
+        }
+        .future-text ul li {
+            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text-secondary);
+            font-weight: 500;
+        }
+        .future-text ul li i {
+            color: var(--accent);
+        }
+        .future-icon {
+            flex: 0.5;
+            font-size: 4rem;
+            color: rgba(141,33,35,0.15);
+            text-align: center;
+        }
+
+        /* ===== RESPONSIVE ===== */
+        @media (max-width: 768px) {
+            .pub-item {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .download-btn {
+                width: 100%;
+                text-align: center;
+            }
+            .future-card {
+                flex-direction: column;
+                padding: 30px;
+            }
+            .future-icon {
+                font-size: 3rem;
+            }
+        }
+    </style>
 </head>
 
 <body>
 
+    <!-- ================= HEADER (NAVBAR) ================= -->
     <header id="header">
         <div id="navbar-placeholder"></div>
     </header>
 
     <main>
 
-        <!-- HERO -->
+        <!-- ================= HERO ================= -->
         <section class="partners-hero">
             <div class="hero-inner">
-                <div class="hero-content">
-                    <span class="hero-badge">
-                        <i class="fas fa-flask"></i> Scientific Innovation
-                    </span>
-                    <h1>Partners & Research</h1>
+                <h1>Partners &amp; Research</h1>
+                <p>
+                    PTE Academic's AI scoring models are backed by rigorous linguistic research,
+                    machine learning studies, and trusted partnerships worldwide.
+                </p>
+                <div class="hero-actions">
+                    <a href="#research" class="primary-btn">View Research</a>
+                    <a href="#partners" class="secondary-btn">Our Partners</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= RESEARCH COLLABORATIONS ================= -->
+        <section id="research" class="features-section reveal">
+            <div class="features-heading">
+                <h2>Research Collaborations</h2>
+                <p>We collaborate with global educational research bodies to advance machine learning scoring systems and cognitive language assessments.</p>
+            </div>
+            <div class="features-container">
+                <div class="feature-box">
+                    <i class="fas fa-brain"></i>
+                    <h3>AI Scoring Validity Study</h3>
+                    <p>A multi-year investigation proving that machine-graded responses correlate to a 0.96 coefficient with senior human examiners.</p>
+                </div>
+                <div class="feature-box">
+                    <i class="fas fa-language"></i>
+                    <h3>Acoustic Modeling across Accents</h3>
+                    <p>Deep neural networks in ASR ensure 100% scoring fairness across 120+ international regional accents.</p>
+                </div>
+                <div class="feature-box">
+                    <i class="fas fa-scale-balanced"></i>
+                    <h3>Assessment Equity &amp; Bias Elimination</h3>
+                    <p>Analyzing candidate data across genders and demographics to validate that automated testing eliminates subjective grading bias.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= ACADEMIC & INDUSTRY PARTNERS ================= -->
+        <section id="partners" class="features-section reveal" style="background:var(--bg-secondary);">
+            <div class="features-heading">
+                <h2>Our Global Network</h2>
+                <p>We work side-by-side with leading universities, research labs, and government bodies.</p>
+            </div>
+
+            <h3 style="text-align:center; margin-top:20px; color:var(--text-primary);">Academic Institutions &amp; Research Labs</h3>
+            <div class="logo-grid">
+                <div class="logo-box"><i class="fas fa-university"></i><span>Stanford Lang Lab</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Melbourne Language Inst</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Oxford Ling Dept</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Toronto AI Centre</span></div>
+            </div>
+
+            <h3 style="text-align:center; margin-top:50px; color:var(--text-primary);">Industry &amp; Government Recognition</h3>
+            <div class="logo-grid">
+                <div class="logo-box"><i class="fas fa-passport"></i><span>Aussie Home Affairs</span></div>
+                <div class="logo-box"><i class="fas fa-passport"></i><span>IRCC Canada</span></div>
+                <div class="logo-box"><i class="fas fa-passport"></i><span>UK Home Office</span></div>
+                <div class="logo-box"><i class="fas fa-user-md"></i><span>Global Nursing Council</span></div>
+            </div>
+        </section>
+
+        <!-- ================= PUBLICATIONS & RESOURCES ================= -->
+        <section id="publications" class="features-section reveal">
+            <div class="features-heading">
+                <h2>Publications &amp; Resources</h2>
+                <p>Download official white papers, research reports, and technical manuals.</p>
+            </div>
+            <div class="pub-list">
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>PTE Academic Technical Manual v4.2</h4>
+                            <p>Comprehensive manual outlining scoring algorithms, standard error of measurement (SEM), and test security frameworks.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (4.2 MB)</button>
+                </div>
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>AI Scoring Validation and Reliability White Paper</h4>
+                            <p>Validation tests proving the alignment of automated assessment with human evaluation results.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (2.8 MB)</button>
+                </div>
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>PTE Score Concordance with IELTS and TOEFL</h4>
+                            <p>Official reference concordance charts mapping PTE Academic overall scores to corresponding IELTS and TOEFL levels.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (1.1 MB)</button>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= FUTURE INITIATIVES ================= -->
+        <section style="padding: clamp(56px, 8vw, 96px) 20px; background:var(--bg-secondary);">
+            <div class="future-card">
+                <div class="future-text">
+                    <h2>Future Initiatives</h2>
                     <p>
-                        PTE Academic's AI scoring models and assessments are backed by rigorous linguistic research, machine learning studies, and trusted partnerships worldwide.
+                        We are actively exploring next-generation testing methodologies, including adaptive cognitive testing
+                        and LLM-assisted grammar diagnostics, to deliver even faster, more precise, and highly personalised
+                        learning feedback.
                     </p>
-                    <div class="hero-actions">
-                        <a href="#research" class="primary-btn">View Research</a>
-                        <a href="#partners" class="secondary-btn">Our Partners</a>
-                    </div>
+                    <ul>
+                        <li><i class="fas fa-arrow-right"></i> Next-Gen LLM scoring models</li>
+                        <li><i class="fas fa-arrow-right"></i> Dynamic test questions custom-tailored to skill gaps</li>
+                        <li><i class="fas fa-arrow-right"></i> Free predictive scoring reports for low-income regions</li>
+                    </ul>
                 </div>
-                <div class="hero-mascot-container">
-                    <div class="mascot-speech-left">
-                        <p>Our AI-driven testing is scientifically validated to be 100% fair and unbiased!</p>
-                    </div>
-                    <img src="../assets/images/mascot.png" alt="PTE Hub Mascot" class="hero-mascot">
+                <div class="future-icon">
+                    <i class="fas fa-microchip"></i>
                 </div>
             </div>
         </section>
 
-        <!-- RESEARCH COLLABORATIONS -->
-        <section id="research" class="partners-section">
+        <!-- ================= CTA ================= -->
+        <section class="about-cta" style="margin-top:0;">
             <div class="container">
-                <h2 class="center-heading">Research Collaborations</h2>
-                <p class="section-subtitle">We collaborate with global educational research bodies to advance machine learning scoring systems and cognitive language assessments.</p>
-                
-                <div class="research-grid">
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-brain"></i></div>
-                        <h3>AI Scoring Validity Study</h3>
-                        <p>A multi-year investigation proving that machine-graded spoken and written responses correlate to a 0.96 coefficient with senior human examiners.</p>
-                        <span class="research-meta">Published: Journal of Educational Measurement (2025)</span>
-                    </div>
-
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-language"></i></div>
-                        <h3>Acoustic Modeling across Accents</h3>
-                        <p>Researching deep neural networks in automatic speech recognition to ensure 100% scoring fairness across 120+ international regional accents.</p>
-                        <span class="research-meta">Published: International Speech Communication Association (2025)</span>
-                    </div>
-
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-scale-balanced"></i></div>
-                        <h3>Assessment Equity & Bias Elimination</h3>
-                        <p>Analyzing candidate data across genders and demographic origins to validate that computerized tests eliminate subjective grading bias.</p>
-                        <span class="research-meta">Published: Language Testing Quarterly (2026)</span>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ACADEMIC & INDUSTRY PARTNERS -->
-        <section id="partners" class="partners-section light">
-            <div class="container">
-                <h2 class="center-heading">Our Global Network</h2>
-                
-                <div class="network-tabs">
-                    <div class="network-tab-content">
-                        <h3>Academic Institutions & Research Labs</h3>
-                        <p class="network-desc">We work side-by-side with leading university language departments to align our curriculum and validate test frameworks.</p>
-                        
-                        <div class="partner-logos-grid">
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Stanford Lang Lab</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Melbourne Language Inst</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Oxford Ling Dept</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Toronto AI Centre</span>
-                            </div>
-                        </div>
-
-                        <h3 class="margin-top-section">Industry & Government Recognition</h3>
-                        <p class="network-desc">Our assessments are recognized for immigration, border protection, and professional licensing in key destinations.</p>
-                        
-                        <div class="partner-logos-grid">
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>Aussie Home Affairs</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>IRCC Canada</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>UK Home Office</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-user-md"></i>
-                                <span>Global Nursing Council</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- PUBLICATIONS & RESOURCES -->
-        <section id="publications" class="partners-section">
-            <div class="container">
-                <h2 class="center-heading">Publications & Resources</h2>
-                <p class="section-subtitle">Download official white papers, research reports, and technical manuals detailing our exam structure and validation standards.</p>
-                
-                <div class="publications-list">
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>PTE Academic Technical Manual v4.2</h4>
-                                <p>Comprehensive manual outlining scoring algorithms, standard error of measurement (SEM), and test security frameworks.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (4.2 MB)</button>
-                    </div>
-
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>AI Scoring Validation and Reliability White Paper</h4>
-                                <p>A summary of validation tests proving the alignment of automated assessment with human evaluation results.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (2.8 MB)</button>
-                    </div>
-
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>PTE Score Concordance with IELTS and TOEFL</h4>
-                                <p>Official reference concordance charts mapping PTE Academic overall scores to corresponding IELTS and TOEFL levels.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (1.1 MB)</button>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- FUTURE INITIATIVES -->
-        <section class="future-initiatives-section">
-            <div class="container">
-                <div class="future-wrapper">
-                    <div class="future-text">
-                        <h2>Future Initiatives</h2>
-                        <p>We are actively exploring next-generation testing methodologies, including adaptive cognitive testing and LLM-assisted grammar diagnostics, to deliver even faster, more precise, and highly personalized learning feedback.</p>
-                        <ul class="future-points">
-                            <li><i class="fas fa-arrow-right"></i> Next-Gen LLM scoring models</li>
-                            <li><i class="fas fa-arrow-right"></i> Dynamic test questions custom-tailored to skill gaps</li>
-                            <li><i class="fas fa-arrow-right"></i> Free predictive scoring reports for low-income regions</li>
-                        </ul>
-                    </div>
-                    <div class="future-deco">
-                        <i class="fas fa-microchip future-icon"></i>
-                    </div>
-                </div>
+                <h2>Join Our Research Community</h2>
+                <p>Collaborate with us to shape the future of AI-driven language assessment.</p>
+                <button class="primary-btn" onclick="alert('Contact us at research@ptehub.com')">Get Involved</button>
             </div>
         </section>
 
     </main>
 
+    <!-- ================= FOOTER & POPUP PLACEHOLDERS ================= -->
     <div id="footer-placeholder"></div>
     <div id="auth-popup-placeholder"></div>
 
+    <!-- ================= SCRIPTS ================= -->
     <script src="../scripts/js/navbar.js"></script>
     <script src="../scripts/js/footer.js"></script>
     <script src="../scripts/js/script.js"></script>
     <script src="../scripts/js/auth-popup.js"></script>
+    <script src="../scripts/js/theme.js"></script>
 
 </body>
 </html>

--- a/pages/pte-test.html
+++ b/pages/pte-test.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,6 +26,7 @@
             text-align: center;
             color: white;
         }
+
         .test-hero::before {
             content: "";
             position: absolute;
@@ -32,39 +34,46 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(135deg, rgba(0,0,0,0.65), rgba(141,33,35,0.75));
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.65), rgba(141, 33, 35, 0.75));
             z-index: 1;
         }
+
         .test-hero .hero-inner {
             position: relative;
             z-index: 2;
             max-width: 800px;
             padding: 0 20px;
         }
+
         .test-hero h1 {
             font-size: 52px;
             margin-bottom: 20px;
             font-weight: 700;
-            text-shadow: 0 2px 15px rgba(0,0,0,0.4);
+            text-shadow: 0 2px 15px rgba(0, 0, 0, 0.4);
         }
+
         .test-hero p {
             font-size: 22px;
-            color: rgba(255,255,255,0.95);
+            color: rgba(255, 255, 255, 0.95);
             max-width: 700px;
             margin: 0 auto;
-            text-shadow: 0 1px 6px rgba(0,0,0,0.3);
+            text-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
         }
+
         .test-section {
             padding: 80px 20px;
             text-align: center;
-            background: #ffffff;
+            background: var(--bg-primary);
         }
+
         .test-section.light {
-            background: #f8f9fc;
+            background: var(--bg-secondary);
         }
+
         .test-section.dark-bg {
-            background: linear-gradient(120deg, #f0f2f5, #ffffff);
+            background: linear-gradient(120deg, var(--bg-secondary), var(--bg-primary));
         }
+
         .test-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -72,33 +81,39 @@
             max-width: 1200px;
             margin: 40px auto 0;
         }
+
         .test-card {
-            background: white;
+            background: var(--bg-card);
             padding: 30px 20px;
             border-radius: 20px;
-            box-shadow: 0 12px 28px rgba(0,0,0,0.08);
+            box-shadow: var(--shadow-card);
             transition: 0.3s ease;
             backdrop-filter: blur(2px);
-            border: 1px solid rgba(255,255,255,0.3);
+            border: 1px solid var(--border-card);
         }
+
         .test-card:hover {
             transform: translateY(-6px);
-            box-shadow: 0 24px 48px rgba(141,33,35,0.15);
+            box-shadow: 0 24px 48px rgba(141, 33, 35, 0.15);
         }
+
         .test-card i {
             font-size: 42px;
             color: #8d2123;
             margin-bottom: 18px;
         }
+
         .test-card h3 {
             font-size: 22px;
             margin-bottom: 12px;
         }
+
         .test-card p {
-            color: #555;
+            color: var(--text-muted);
             font-size: 14px;
             line-height: 1.6;
         }
+
         .score-badge {
             display: inline-block;
             background: #8d2123;
@@ -109,28 +124,32 @@
             margin: 20px 0 10px;
             letter-spacing: 1px;
         }
+
         .centre-list {
-            background: white;
+            background: var(--bg-card);
             border-radius: 20px;
             padding: 20px 35px;
             max-width: 800px;
             margin: 30px auto 0;
             text-align: left;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+            box-shadow: var(--shadow-card);
         }
+
         .centre-list li {
             padding: 12px 0;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-input);
             display: flex;
             align-items: center;
             gap: 14px;
             font-size: 15px;
         }
+
         .centre-list li i {
             color: #8d2123;
             width: 26px;
             font-size: 18px;
         }
+
         .btn-secondary {
             background: #8d2123;
             color: white;
@@ -142,23 +161,39 @@
             cursor: pointer;
             transition: 0.25s;
             margin-top: 32px;
-            box-shadow: 0 4px 12px rgba(141,33,35,0.3);
+            box-shadow: 0 4px 12px rgba(141, 33, 35, 0.3);
         }
+
         .btn-secondary:hover {
             background: #6f1a1c;
             transform: translateY(-3px);
-            box-shadow: 0 8px 20px rgba(141,33,35,0.4);
+            box-shadow: 0 8px 20px rgba(141, 33, 35, 0.4);
         }
+
         @media (max-width: 768px) {
-            .test-hero h1 { font-size: 32px; }
-            .test-hero p { font-size: 18px; }
-            .centre-list li { flex-wrap: wrap; gap: 8px; }
-            .test-hero { min-height: 70vh; }
+            .test-hero h1 {
+                font-size: 32px;
+            }
+
+            .test-hero p {
+                font-size: 18px;
+            }
+
+            .centre-list li {
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .test-hero {
+                min-height: 70vh;
+            }
         }
+
         .test-section.light {
-            background-image: radial-gradient(circle at 10% 20%, rgba(141,33,35,0.02) 2%, transparent 2.5%);
+            background-image: radial-gradient(circle at 10% 20%, rgba(141, 33, 35, 0.02) 2%, transparent 2.5%);
             background-size: 28px 28px;
         }
+
         /* Offset for fixed navbar */
         section[id] {
             scroll-margin-top: 90px;
@@ -167,114 +202,118 @@
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 </head>
+
 <body>
 
-<header id="header">
-    <div id="navbar-placeholder"></div>
-</header>
+    <header id="header">
+        <div id="navbar-placeholder"></div>
+    </header>
 
-<main>
+    <main>
 
-    <!-- Hero Section -->
-    <section class="test-hero">
-        <div class="hero-inner">
-            <h1>PTE Academic - The Smarter English Test</h1>
-            <p>Fully computer-based, AI-scored, and trusted by governments & universities worldwide.</p>
-        </div>
-    </section>
+        <!-- Hero Section -->
+        <section class="test-hero">
+            <div class="hero-inner">
+                <h1>PTE Academic - The Smarter English Test</h1>
+                <p>Fully computer-based, AI-scored, and trusted by governments & universities worldwide.</p>
+            </div>
+        </section>
 
-    <!-- What is PTE? (ID added) -->
-    <section id="what-is-pte" class="test-section dark-bg">
-        <div class="container" style="max-width: 900px; margin: auto;">
-            <h2>What is PTE Academic?</h2>
-            <p style="font-size: 18px; color: #444; max-width: 750px; margin: 20px auto;">
-                PTE Academic assesses real-life English communication skills. It uses AI to deliver fair,
-                unbiased results – often within 48 hours. No human bias, no unexpected surprises.
+        <!-- What is PTE? (ID added) -->
+        <section id="what-is-pte" class="test-section dark-bg">
+            <div class="container" style="max-width: 900px; margin: auto;">
+                <h2>What is PTE Academic?</h2>
+                <p style="font-size: 18px; color: var(--text-secondary); max-width: 750px; margin: 20px auto;">
+                    PTE Academic assesses real-life English communication skills. It uses AI to deliver fair,
+                    unbiased results – often within 48 hours. No human bias, no unexpected surprises.
+                </p>
+            </div>
+        </section>
+
+        <!-- Test Format (ID added) -->
+        <section id="test-format" class="test-section light">
+            <h2>Test Format</h2>
+            <p style="color: var(--text-muted); max-width: 700px; margin: 0 auto 20px;">The exam takes ~2 hours and
+                includes 20 different task types.</p>
+            <div class="test-grid">
+                <div class="test-card">
+                    <i class="fas fa-microphone-alt"></i>
+                    <h3>Speaking & Writing</h3>
+                    <p>Read aloud, repeat sentences, describe image, summarize text – 54–67 min.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-book-open"></i>
+                    <h3>Reading</h3>
+                    <p>Multiple choice, reorder paragraphs, fill in the blanks – 29–30 min.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-headphones"></i>
+                    <h3>Listening</h3>
+                    <p>Summarize spoken text, highlight incorrect words, write from dictation – 30–43 min.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scoring System (ID added) -->
+        <section id="scoring-system" class="test-section dark-bg">
+            <h2>Scoring System</h2>
+            <div class="score-badge">Overall score range: 10 – 90</div>
+            <p style="max-width: 750px; margin: 15px auto; color: var(--text-muted);">
+                PTE uses <strong>automated scoring</strong> based on thousands of real test-takers. Each skill (grammar,
+                oral fluency, pronunciation, spelling, vocabulary, written discourse) is scored individually.
+                Results are typically available <strong>within 48 hours</strong>.
             </p>
-        </div>
-    </section>
-
-    <!-- Test Format (ID added) -->
-    <section id="test-format" class="test-section light">
-        <h2>Test Format</h2>
-        <p style="color: #555; max-width: 700px; margin: 0 auto 20px;">The exam takes ~2 hours and includes 20 different task types.</p>
-        <div class="test-grid">
-            <div class="test-card">
-                <i class="fas fa-microphone-alt"></i>
-                <h3>Speaking & Writing</h3>
-                <p>Read aloud, repeat sentences, describe image, summarize text – 54–67 min.</p>
+            <div class="test-grid" style="margin-top: 30px;">
+                <div class="test-card">
+                    <i class="fas fa-chart-line"></i>
+                    <h3>Enabling Skills</h3>
+                    <p>Grammar, oral fluency, pronunciation, spelling, vocabulary.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-crosshairs"></i>
+                    <h3>Communicative Skills</h3>
+                    <p>Listening, Reading, Speaking, Writing – each scored 10–90.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-clock"></i>
+                    <h3>Fast Reporting</h3>
+                    <p>Scores sent to unlimited institutions for free.</p>
+                </div>
             </div>
-            <div class="test-card">
-                <i class="fas fa-book-open"></i>
-                <h3>Reading</h3>
-                <p>Multiple choice, reorder paragraphs, fill in the blanks – 29–30 min.</p>
+        </section>
+
+        <!-- Test Centers (ID added) -->
+        <section id="test-centers" class="test-section light">
+            <h2>PTE Test Centres</h2>
+            <p>Authorised centres worldwide – find one near you.</p>
+            <div class="centre-list">
+                <li><i class="fas fa-map-marker-alt"></i> <strong>New Delhi, India</strong> – Connaught Place</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Melbourne, Australia</strong> – CBD, near Flinders St
+                </li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>London, UK</strong> – Holborn Centre</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Toronto, Canada</strong> – Yonge Street</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Auckland, New Zealand</strong> – Queen Street</li>
             </div>
-            <div class="test-card">
-                <i class="fas fa-headphones"></i>
-                <h3>Listening</h3>
-                <p>Summarize spoken text, highlight incorrect words, write from dictation – 30–43 min.</p>
-            </div>
-        </div>
-    </section>
+            <button class="btn-secondary" id="findCentreBtn">Find a Test Centre →</button>
+        </section>
 
-    <!-- Scoring System (ID added) -->
-    <section id="scoring-system" class="test-section dark-bg">
-        <h2>Scoring System</h2>
-        <div class="score-badge">Overall score range: 10 – 90</div>
-        <p style="max-width: 750px; margin: 15px auto; color: #555;">
-            PTE uses <strong>automated scoring</strong> based on thousands of real test-takers. Each skill (grammar,
-            oral fluency, pronunciation, spelling, vocabulary, written discourse) is scored individually.
-            Results are typically available <strong>within 48 hours</strong>.
-        </p>
-        <div class="test-grid" style="margin-top: 30px;">
-            <div class="test-card">
-                <i class="fas fa-chart-line"></i>
-                <h3>Enabling Skills</h3>
-                <p>Grammar, oral fluency, pronunciation, spelling, vocabulary.</p>
-            </div>
-            <div class="test-card">
-                <i class="fas fa-crosshairs"></i>
-                <h3>Communicative Skills</h3>
-                <p>Listening, Reading, Speaking, Writing – each scored 10–90.</p>
-            </div>
-            <div class="test-card">
-                <i class="fas fa-clock"></i>
-                <h3>Fast Reporting</h3>
-                <p>Scores sent to unlimited institutions for free.</p>
-            </div>
-        </div>
-    </section>
+    </main>
 
-    <!-- Test Centers (ID added) -->
-    <section id="test-centers" class="test-section light">
-        <h2>PTE Test Centres</h2>
-        <p>Authorised centres worldwide – find one near you.</p>
-        <div class="centre-list">
-            <li><i class="fas fa-map-marker-alt"></i> <strong>New Delhi, India</strong> – Connaught Place</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Melbourne, Australia</strong> – CBD, near Flinders St</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>London, UK</strong> – Holborn Centre</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Toronto, Canada</strong> – Yonge Street</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Auckland, New Zealand</strong> – Queen Street</li>
-        </div>
-        <button class="btn-secondary" id="findCentreBtn">Find a Test Centre →</button>
-    </section>
+    <div id="footer-placeholder"></div>
+    <div id="auth-popup-placeholder"></div>
 
-</main>
+    <script src="../scripts/js/navbar.js"></script>
+    <script src="../scripts/js/footer.js"></script>
+    <script src="../scripts/js/theme.js"></script>
+    <script src="../scripts/js/script.js"></script>
+    <script src="../scripts/js/auth-popup.js"></script>
 
-<div id="footer-placeholder"></div>
-<div id="auth-popup-placeholder"></div>
-
-<script src="../scripts/js/navbar.js"></script>
-<script src="../scripts/js/footer.js"></script>
-<script src="../scripts/js/theme.js"></script>
-<script src="../scripts/js/script.js"></script>
-<script src="../scripts/js/auth-popup.js"></script>
-
-<script>
-    document.getElementById('findCentreBtn')?.addEventListener('click', () => {
-        alert('Full test centre locator coming soon. Visit the official PTE website for the latest list.');
-    });
-</script>
+    <script>
+        document.getElementById('findCentreBtn')?.addEventListener('click', () => {
+            alert('Full test centre locator coming soon. Visit the official PTE website for the latest list.');
+        });
+    </script>
 
 </body>
+
 </html>

--- a/scripts/js/auth-popup.js
+++ b/scripts/js/auth-popup.js
@@ -9,6 +9,8 @@ document.addEventListener("DOMContentLoaded", () => {
             const container = document.getElementById("auth-popup-placeholder");
             if(container){
                 container.innerHTML = data;
+
+
             }
         });
 

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -4,34 +4,34 @@ const isSubpage = window.location.pathname.includes('/pages/');
 const footerPath = isSubpage ? '../components/footer.html' : 'components/footer.html';
 
 fetch(footerPath)
-.then(response => response.text())
-.then(data => {
+  .then(response => response.text())
+  .then(data => {
 
-  document.getElementById("footer-placeholder").innerHTML = data;
+    document.getElementById("footer-placeholder").innerHTML = data;
 
-  // Newsletter form functionality
+    // Newsletter form functionality
 
-  const form = document.getElementById("newsletter-form");
+    const form = document.getElementById("newsletter-form");
 
-  if(form){
+    if (form) {
 
-    form.addEventListener("submit", function(e){
+      form.addEventListener("submit", function (e) {
 
-      e.preventDefault();
+        e.preventDefault();
 
-      const email = document.getElementById("newsletter-email").value;
+        const email = document.getElementById("newsletter-email").value;
 
-      if(email.trim() === ""){
-        alert("Please enter a valid email.");
-        return;
-      }
+        if (email.trim() === "") {
+          alert("Please enter a valid email.");
+          return;
+        }
 
-      alert("Thank you for subscribing!");
+        alert("Thank you for subscribing!");
 
-      form.reset();
+        form.reset();
 
-    });
+      });
 
-  }
+    }
 
-});
+  });

--- a/scripts/js/navbar.js
+++ b/scripts/js/navbar.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", function () {
 
-    fetch("../components/navbar.html")
+    const isSubpage = window.location.pathname.includes('/pages/');
+    const navbarPath = isSubpage ? '../components/navbar.html' : 'components/navbar.html';
+
+    fetch(navbarPath)
         .then(response => response.text())
         .then(data => {
         
@@ -9,6 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!placeholder) return;
         
             placeholder.innerHTML = data;
+
+
 
         const hamburger = document.getElementById("hamburger");
         const navbar = document.getElementById("navbar");

--- a/styles/css/style.css
+++ b/styles/css/style.css
@@ -9,7 +9,8 @@ body {
 
 /* Header */
 #header {
-    position: absolute; /* overlay on hero */
+    position: absolute;
+    /* overlay on hero */
     top: 0;
     left: 0;
     width: 100%;
@@ -22,7 +23,8 @@ body {
 
     z-index: 999;
 
-    background: transparent; /* IMPORTANT */
+    background: transparent;
+    /* IMPORTANT */
 }
 
 #header img {
@@ -31,19 +33,19 @@ body {
 }
 
 #navbar-container {
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-    width:100%;
-    position:relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
 }
 
 #navbar {
-    display:flex;
-    flex-direction:row;
-    align-items:center;
-    justify-content:center;
-    gap:20px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
 }
 
 #navbar li {
@@ -71,25 +73,28 @@ body {
     display: none;
 }
 
-#address, #address1{
-    background:#8d2123;
-    color:white;
-    border:none;
-    border-radius:8px;
-    padding:12px 26px;
-    font-size:15px;
-    font-weight:600;
-    cursor:pointer;
-    transition:all 0.3s ease;
+#address,
+#address1 {
+    background: #8d2123;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 26px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
 }
 
-#address:hover, #address1:hover{
-    background:#6a181b;
-    transform:translateY(-2px);
-    box-shadow:0 8px 20px rgba(0,0,0,0.3);
+#address:hover,
+#address1:hover {
+    background: #6a181b;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
 }
 
-#address:hover, #address1:hover {
+#address:hover,
+#address1:hover {
     background-color: #6a181b;
 }
 
@@ -104,217 +109,219 @@ body {
 }
 
 /* Hero Section */
-.hero-image{
-    background-image:url('../../assets/images/hero.jpg');
-    background-size:cover;
-    background-position:center;
+.hero-image {
+    background-image: url('../../assets/images/hero.jpg');
+    background-size: cover;
+    background-position: center;
     width: 100%;
     position: relative;
     overflow: hidden;
-    min-height:calc(100vh - 80px); /* adjust based on navbar height */
+    min-height: calc(100vh - 80px);
+    /* adjust based on navbar height */
 
-    display:flex;
+    display: flex;
     flex: 1;
-    padding:80px 40px 40px 40px;
+    padding: 80px 40px 40px 40px;
 }
 
-.hero-wrapper{
-    display:flex;
-    align-items:center;
-    justify-content:flex-start;
-    max-width:1200px;
-    width:100%;
-        padding:80px 40px 40px 40px;
+.hero-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    max-width: 1200px;
+    width: 100%;
+    padding: 80px 40px 40px 40px;
 
-    padding:80px 40px 40px 40px;
+    padding: 80px 40px 40px 40px;
 }
 
-.hero-text{
-    max-width:460px;
-    background:rgba(255,255,255,0.85);
-    backdrop-filter:blur(14px);
-    padding:25px 38px 35px 38px;
-    border-radius:8px;
-    box-shadow:0 20px 60px rgba(0,0,0,0.22);
-    border:1px solid rgba(255,255,255,0.35);
+.hero-text {
+    max-width: 460px;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(14px);
+    padding: 25px 38px 35px 38px;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.35);
 }
 
-.hero-text h2{
-    font-size:38px;
-    font-weight:700;
-    line-height:1.25;
-    margin-top:0;
-    margin-bottom:12px;
-    color:#1a1a1a;
+.hero-text h2 {
+    font-size: 38px;
+    font-weight: 700;
+    line-height: 1.25;
+    margin-top: 0;
+    margin-bottom: 12px;
+    color: #1a1a1a;
 }
 
-.hero-text h3{
-    font-size:24px;
-    font-weight:500;
-    margin-bottom:22px;
-    color:#444;
+.hero-text h3 {
+    font-size: 24px;
+    font-weight: 500;
+    margin-bottom: 22px;
+    color: #444;
 }
 
-.hero-text p{
-    margin:8px 0;
-    font-size:15px;
-    line-height:1.6;
-    color:#555;
+.hero-text p {
+    margin: 8px 0;
+    font-size: 15px;
+    line-height: 1.6;
+    color: #555;
 }
 
-.hero-text button{
-    margin-top:22px;
+.hero-text button {
+    margin-top: 22px;
 }
 
-.hero-points{
-    list-style:none;
-    padding:0;
-    margin:18px 0 22px 0;
+.hero-points {
+    list-style: none;
+    padding: 0;
+    margin: 18px 0 22px 0;
 }
 
-.hero-points li{
-    display:flex;
-    align-items:flex-start;
-    gap:10px;
-    font-size:15px;
-    color:#555;
-    margin-bottom:8px;
-    line-height:1.5;
+.hero-points li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 15px;
+    color: #555;
+    margin-bottom: 8px;
+    line-height: 1.5;
 }
 
-.hero-points i{
-    color:#8d2123;
-    margin-top:3px;
-    font-size:14px;
+.hero-points i {
+    color: #8d2123;
+    margin-top: 3px;
+    font-size: 14px;
 }
 
-.hero-actions{
-    margin-top:10px;
+.hero-actions {
+    margin-top: 10px;
 }
 
-section.reveal{
-    padding:80px 20px;
-    text-align:center;
+section.reveal {
+    padding: 80px 20px;
+    text-align: center;
 }
 
-section.reveal:nth-of-type(even){
-    background:#ffffff;
+section.reveal:nth-of-type(even) {
+    background: #ffffff;
 }
 
-section.reveal:nth-of-type(odd){
-    background:#f7f7f7;
+section.reveal:nth-of-type(odd) {
+    background: #f7f7f7;
 }
 
-.features-heading h2{
-    font-size:32px;
-    margin-bottom:10px;
+.features-heading h2 {
+    font-size: 32px;
+    margin-bottom: 10px;
 }
 
-.features-heading p{
-    color:#555;
-    margin-bottom:40px;
+.features-heading p {
+    color: #555;
+    margin-bottom: 40px;
 }
 
-#page2{
-    background:#ffffff;
-    padding:80px 20px;
+#page2 {
+    background: #ffffff;
+    padding: 80px 20px;
 }
 
-#alpha{
-    text-align:center;
-    margin-bottom:40px;
+#alpha {
+    text-align: center;
+    margin-bottom: 40px;
 }
 
-#alpha h2{
-    font-size:32px;
-    color:#1a1a1a;
+#alpha h2 {
+    font-size: 32px;
+    color: #1a1a1a;
 }
 
-#alpha p{
-    color:#555;
+#alpha p {
+    color: #555;
 }
 
 
 /* Cards Section */
-#container{
-    max-width:1200px;
-    margin:auto;
-    display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
-    gap:30px;
+#container {
+    max-width: 1200px;
+    margin: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 30px;
 }
 
-#container .cards::after{
-    content:"";
-    position:absolute;
-    inset:0;
-    background:linear-gradient(120deg, transparent, rgba(255,255,255,0.3), transparent);
-    opacity:0;
-    transition:0.4s;
+#container .cards::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+    opacity: 0;
+    transition: 0.4s;
     pointer-events: none;
 }
 
-#container .cards:hover::after{
-    opacity:1;
+#container .cards:hover::after {
+    opacity: 1;
 }
 
-#container .cards{
-    width:100%;
-    background:#ffffff;
+#container .cards {
+    width: 100%;
+    background: #ffffff;
 
-    border-radius:12px;
-    overflow:visible;
-    position:relative;
+    border-radius: 12px;
+    overflow: visible;
+    position: relative;
 
-    box-shadow:0 10px 25px rgba(0,0,0,0.08);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
 
-    transition:all 0.4s ease;
+    transition: all 0.4s ease;
 
-    text-align:center;
-    padding-bottom:25px;
+    text-align: center;
+    padding-bottom: 25px;
 }
 
 
 
-#address, #address1{
-    letter-spacing:0.5px;
+#address,
+#address1 {
+    letter-spacing: 0.5px;
 }
 
-#container .cards:hover{
-    transform:translateY(-10px);
-    box-shadow:0 20px 40px rgba(0,0,0,0.15);
+#container .cards:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
 }
 
-#container .cards img{
-    width:100%;
-    height:220px;
+#container .cards img {
+    width: 100%;
+    height: 220px;
 
-    object-fit:cover;
+    object-fit: cover;
 
-    border-top-left-radius:12px;
-    border-top-right-radius:12px;
+    border-top-left-radius: 12px;
+    border-top-right-radius: 12px;
 
-    transition:transform 0.4s ease;
+    transition: transform 0.4s ease;
 }
 
-#container .cards:hover img{
-    transform:scale(1.08);
+#container .cards:hover img {
+    transform: scale(1.08);
 }
 
-#container .cards h3{
-    margin-top:20px;
-    font-size:20px;
-    color:#1a1a1a;
+#container .cards h3 {
+    margin-top: 20px;
+    font-size: 20px;
+    color: #1a1a1a;
 }
 
-#container .cards p{
-    padding:0 20px;
-    color:#555;
-    line-height:1.5;
+#container .cards p {
+    padding: 0 20px;
+    color: #555;
+    line-height: 1.5;
 }
 
-#container .cards button{
-    margin-top:15px;
+#container .cards button {
+    margin-top: 15px;
 }
 
 /* Book Now Button */
@@ -344,52 +351,66 @@ section.reveal:nth-of-type(odd){
 .book-now-btn:active {
     transform: translateY(0);
 }
+
 /* Reviews Section */
 #contact {
-    background:#f7f7f7;
-    padding:80px 20px;
+    background: #f7f7f7;
+    padding: 80px 20px;
     text-align: center;
 }
 
-#reviews{
-    max-width:1100px;
-    margin:40px auto;
-
-    display:flex;
-    gap:25px;
-
-    overflow-x:auto;
-    scroll-behavior:smooth;
-
-    padding-bottom:10px;
+.reviews-scroll-wrapper {
+    overflow: hidden;
+    width: 100%;
+    max-width: 1100px;
+    margin: 40px auto;
+    position: relative;
 }
 
-#reviews::-webkit-scrollbar{
-    height:6px;
+#reviews {
+    display: flex;
+    width: max-content;
+    animation: scroll-reviews 30s linear infinite;
 }
 
-#reviews::-webkit-scrollbar-thumb{
-    background:#8d2123;
-    border-radius:10px;
+#reviews:hover {
+    animation-play-state: paused;
 }
 
-.review{
-    min-width:240px;
-    max-width:260px;
-    background:#fff;
-
-    padding:25px;
-
-    border-radius:12px;
-
-    box-shadow:0 8px 20px rgba(0,0,0,0.08);
-
-    transition:all 0.3s ease;
+#reviews::-webkit-scrollbar {
+    display: none;
 }
 
-.review:hover{
-    transform:translateY(-6px);
-    box-shadow:0 18px 40px rgba(0,0,0,0.15);
+#reviews {
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    scrollbar-width: none;
+    /* Firefox */
+}
+
+.reviews-slide {
+    display: flex;
+    gap: 25px;
+    padding-right: 25px;
+}
+
+.review {
+    min-width: 240px;
+    max-width: 260px;
+    background: #fff;
+
+    padding: 25px;
+
+    border-radius: 12px;
+
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+
+    transition: all 0.3s ease;
+}
+
+.review:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
 }
 
 .review h3 {
@@ -401,6 +422,16 @@ section.reveal:nth-of-type(odd){
 .review p {
     font-size: 1em;
     color: #555;
+}
+
+@keyframes scroll-reviews {
+    0% {
+        transform: translateX(0);
+    }
+
+    100% {
+        transform: translateX(-50%);
+    }
 }
 
 /* Footer */
@@ -447,17 +478,17 @@ footer a:hover {
 /* Responsive Adjustments */
 @media (max-width: 768px) {
     #navbar {
-        display:none;
-        flex-direction:column;
-        gap:10px;
-        width:100%;
-        text-align:center;
-        background:#E3E6F3;
-        padding:15px 0;
+        display: none;
+        flex-direction: column;
+        gap: 10px;
+        width: 100%;
+        text-align: center;
+        background: #E3E6F3;
+        padding: 15px 0;
     }
 
-    #navbar.active{
-        display:flex;
+    #navbar.active {
+        display: flex;
     }
 
     #mobile {
@@ -470,7 +501,8 @@ footer a:hover {
         align-items: center;
     }
 
-    #address, #address1 {
+    #address,
+    #address1 {
         width: 100%;
         margin: 10px 0;
     }
@@ -493,7 +525,9 @@ footer a:hover {
         padding: 20px;
     }
 
-    #box1 h2, #box1 h3, #box1 h5 {
+    #box1 h2,
+    #box1 h3,
+    #box1 h5 {
         font-size: 1em;
     }
 
@@ -517,436 +551,455 @@ footer a:hover {
         padding: 10px;
     }
 
-    #address, #address1 {
+    #address,
+    #address1 {
         padding: 8px 15px;
     }
 }
 
-@media (max-width:768px){
+@media (max-width:768px) {
 
-    #point{
-        padding:80px 20px 30px 20px;
-        min-height:auto;
+    #point {
+        padding: 80px 20px 30px 20px;
+        min-height: auto;
     }
 
-    .hero-wrapper{
-        flex-direction:column;
-        justify-content:center;
-        align-items:center;
-        text-align:center;
+    .hero-wrapper {
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
     }
 
-    .hero-text{
-        max-width:100%;
-        padding:20px;
+    .hero-text {
+        max-width: 100%;
+        padding: 20px;
     }
 
-    .hero-text h2{
-        font-size:26px;
+    .hero-text h2 {
+        font-size: 26px;
     }
 
-    .hero-text h3{
-        font-size:18px;
+    .hero-text h3 {
+        font-size: 18px;
     }
 
 }
 
 /* LOGIN REQUIRED POPUP */
 
-.auth-popup-overlay{
+.auth-popup-overlay {
 
-    position:fixed;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 
-    background:rgba(0,0,0,0.45);
+    background: rgba(0, 0, 0, 0.45);
 
-    display:flex;
-    align-items:center;
-    justify-content:center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    z-index:2000;
+    z-index: 2000;
 }
 
-.auth-popup{
+.auth-popup {
 
-    background:white;
-    padding:35px 40px;
+    background: white;
+    padding: 35px 40px;
 
-    border-radius:16px;
+    border-radius: 16px;
 
-    width:320px;
+    width: 320px;
 
-    text-align:center;
+    text-align: center;
 
-    box-shadow:0 15px 40px rgba(0,0,0,0.2);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.2);
 }
 
-.auth-popup h3{
-    margin-bottom:10px;
+.auth-popup h3 {
+    margin-bottom: 10px;
 }
 
-.auth-popup p{
-    font-size:14px;
-    color:#666;
-    margin-bottom:20px;
+.auth-popup p {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 20px;
 }
 
-.auth-popup-actions{
-    display:flex;
-    gap:10px;
-    justify-content:center;
+.auth-popup-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
 }
 
-.popup-login-btn{
+.popup-login-btn {
 
-    background:#2f855a;
-    color:white;
+    background: #2f855a;
+    color: white;
 
-    padding:10px 18px;
+    padding: 10px 18px;
 
-    border-radius:8px;
+    border-radius: 8px;
 
-    text-decoration:none;
+    text-decoration: none;
 }
 
-.popup-close-btn{
+.popup-close-btn {
 
-    padding:10px 18px;
+    padding: 10px 18px;
 
-    border:none;
+    border: none;
 
-    background:#ddd;
+    background: #ddd;
 
-    border-radius:8px;
+    border-radius: 8px;
 
-    cursor:pointer;
+    cursor: pointer;
 }
 
 /* SCROLL TO TOP BUTTON */
 
-#scrollTopBtn{
-  position:fixed;
+#scrollTopBtn {
+    position: fixed;
 
-  bottom:30px;
-  right:30px;
+    bottom: 30px;
+    right: 30px;
 
-  width:44px;
-  height:44px;
+    width: 44px;
+    height: 44px;
 
-  border:none;
-  border-radius:50%;
+    border: none;
+    border-radius: 50%;
 
-  background:#8d2123;
-  color:white;
+    background: #8d2123;
+    color: white;
 
-  font-size:18px;
+    font-size: 18px;
 
-  display:none; /* hidden initially */
+    display: none;
+    /* hidden initially */
 
-  align-items:center;
-  justify-content:center;
+    align-items: center;
+    justify-content: center;
 
-  cursor:pointer;
+    cursor: pointer;
 
-  box-shadow:0 6px 18px rgba(0,0,0,0.25);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
 
-  transition:all 0.25s ease;
+    transition: all 0.25s ease;
 
-  z-index:9999;
+    z-index: 9999;
 }
 
-#scrollTopBtn.show{
-  display:flex;
+#scrollTopBtn.show {
+    display: flex;
 }
 
-#scrollTopBtn:hover{
-  background:#6f181a;
-  transform:translateY(-3px);
+#scrollTopBtn:hover {
+    background: #6f181a;
+    transform: translateY(-3px);
 }
 
 /* ===== MODERN SECTION LAYOUT ===== */
 
-.features-heading h2{
-    font-size:38px;
-    font-weight:700;
-    letter-spacing:-0.5px;
+.features-heading h2 {
+    font-size: 38px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
     margin-bottom: 10px;
-    color:#1a1a1a;
+    color: #1a1a1a;
 }
 
-.features-heading p{
-    font-size:17px;
-    line-height:1.6;
-    max-width:700px;
-    margin:0 auto 50px auto;
-    color:#555;
+.features-heading p {
+    font-size: 17px;
+    line-height: 1.6;
+    max-width: 700px;
+    margin: 0 auto 50px auto;
+    color: #555;
 }
 
 /* grid layout instead of flex */
 
-.features-container{
-    max-width:1200px;
-    margin:auto;
-    display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-    gap:30px;
+.features-container {
+    max-width: 1200px;
+    margin: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 30px;
 }
 
 /* modern cards */
 
-.feature-box{
-    background:white;
-    padding:35px 25px;
+.feature-box {
+    background: white;
+    padding: 35px 25px;
 
-    border-radius:14px;
-    text-align:center;
+    border-radius: 14px;
+    text-align: center;
 
-    box-shadow:0 8px 25px rgba(0,0,0,0.08);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
 
-    position:relative;
-    overflow:hidden;
+    position: relative;
+    overflow: hidden;
 
-    opacity:0;
-    transform:translateY(40px);
+    opacity: 0;
+    transform: translateY(40px);
 
-    transition:all 0.6s ease;
+    transition: all 0.6s ease;
 }
 
-.feature-box::before{
-    content:"";
-    position:absolute;
-    top:0;
-    left:-100%;
-    width:100%;
-    height:100%;
-    background:linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
-    transition:0.6s;
+.feature-box::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+    transition: 0.6s;
 }
 
-.feature-box:hover::before{
-    left:100%;
+.feature-box:hover::before {
+    left: 100%;
 }
 
-.feature-box:hover{
-    transform:translateY(-8px);
-    box-shadow:0 18px 45px rgba(0,0,0,0.15);
+.feature-box:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
 }
 
-.feature-box i{
-    font-size:36px;
-    color:#8d2123;
-    margin-bottom:18px;
+.feature-box i {
+    font-size: 36px;
+    color: #8d2123;
+    margin-bottom: 18px;
 }
 
-.feature-box h3{
-    margin-bottom:12px;
+.feature-box h3 {
+    margin-bottom: 12px;
 }
 
-.feature-box p{
-    font-size:14px;
-    color:#555;
-    line-height:1.5;
+.feature-box p {
+    font-size: 14px;
+    color: #555;
+    line-height: 1.5;
 }
 
 /* ===== SCROLL ANIMATION ===== */
 
-.reveal{
-    opacity:0;
-    transform:translateY(40px);
-    transition:all 0.8s ease;
+.reveal {
+    opacity: 0;
+    transform: translateY(40px);
+    transition: all 0.8s ease;
 }
 
-.reveal.active{
-    opacity:1;
-    transform:translateY(0);
+.reveal.active {
+    opacity: 1;
+    transform: translateY(0);
 }
 
-.reveal.active .feature-box{
-    opacity:1;
-    transform:translateY(0);
+.reveal.active .feature-box {
+    opacity: 1;
+    transform: translateY(0);
 }
 
-.reveal.active .feature-box:nth-child(1){ transition-delay:0.1s; }
-.reveal.active .feature-box:nth-child(2){ transition-delay:0.2s; }
-.reveal.active .feature-box:nth-child(3){ transition-delay:0.3s; }
-.reveal.active .feature-box:nth-child(4){ transition-delay:0.4s; }
+.reveal.active .feature-box:nth-child(1) {
+    transition-delay: 0.1s;
+}
+
+.reveal.active .feature-box:nth-child(2) {
+    transition-delay: 0.2s;
+}
+
+.reveal.active .feature-box:nth-child(3) {
+    transition-delay: 0.3s;
+}
+
+.reveal.active .feature-box:nth-child(4) {
+    transition-delay: 0.4s;
+}
 
 
 /* smooth page scrolling */
 
-html{
-    scroll-behavior:smooth;
+html {
+    scroll-behavior: smooth;
 }
 
 /* SCROLLBAR (modern thin) */
 
-::-webkit-scrollbar{
-    width:6px;   /* vertical */
-    height:6px;  /* horizontal */
+::-webkit-scrollbar {
+    width: 6px;
+    /* vertical */
+    height: 6px;
+    /* horizontal */
 }
 
-::-webkit-scrollbar-track{
-    background:transparent;
+::-webkit-scrollbar-track {
+    background: transparent;
 }
 
-::-webkit-scrollbar-thumb{
-    background:#8d2123;
-    border-radius:10px;
+::-webkit-scrollbar-thumb {
+    background: #8d2123;
+    border-radius: 10px;
 }
 
-::-webkit-scrollbar-thumb:hover{
-    background:#6a181b;
+::-webkit-scrollbar-thumb:hover {
+    background: #6a181b;
 }
 
-#address, #address1{
-    position:relative;
-    overflow:hidden;
+#address,
+#address1 {
+    position: relative;
+    overflow: hidden;
 }
 
-#address::after, #address1::after{
-    content:"";
-    position:absolute;
-    top:0;
-    left:-100%;
-    width:100%;
-    height:100%;
-    background:rgba(255,255,255,0.2);
-    transition:0.4s;
+#address::after,
+#address1::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.2);
+    transition: 0.4s;
 }
 
-#address:hover::after, #address1:hover::after{
-    left:100%;
+#address:hover::after,
+#address1:hover::after {
+    left: 100%;
 }
 
-.hero-text{
-    animation:fadeUp 1s ease;
+.hero-text {
+    animation: fadeUp 1s ease;
 }
 
-@keyframes fadeUp{
-    from{
-        opacity:0;
-        transform:translateY(30px);
+@keyframes fadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
     }
-    to{
-        opacity:1;
-        transform:translateY(0);
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }
 
 /* SCROLL OFFSET FIX (for sticky navbar) */
 
-section{
+section {
     scroll-margin-top: 90px;
 }
 
 /* ===== ULTRA PREMIUM FAQ ===== */
 
-.faq-section{
-    padding:120px 20px;
-    background:linear-gradient(135deg,#f8f9fb,#ffffff);
-    position:relative;
+.faq-section {
+    padding: 120px 20px;
+    background: linear-gradient(135deg, #f8f9fb, #ffffff);
+    position: relative;
 }
 
 /* soft glow */
-.faq-section::before{
-    content:"";
-    position:absolute;
-    top:-100px;
-    left:-100px;
-    width:300px;
-    height:300px;
-    background:rgba(141,33,35,0.08);
-    border-radius:50%;
-    filter:blur(90px);
+.faq-section::before {
+    content: "";
+    position: absolute;
+    top: -100px;
+    left: -100px;
+    width: 300px;
+    height: 300px;
+    background: rgba(141, 33, 35, 0.08);
+    border-radius: 50%;
+    filter: blur(90px);
 }
 
 /* list */
-.faq-list{
-    max-width:850px;
-    margin:auto;
-    display:flex;
-    flex-direction:column;
-    gap:20px;
+.faq-list {
+    max-width: 850px;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }
 
 /* item */
-.faq-item{
-    border-radius:16px;
-    overflow:hidden;
-    background:rgba(255,255,255,0.7);
-    backdrop-filter:blur(12px);
+.faq-item {
+    border-radius: 16px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(12px);
 
-    border:1px solid rgba(255,255,255,0.4);
+    border: 1px solid rgba(255, 255, 255, 0.4);
 
-    box-shadow:0 10px 30px rgba(0,0,0,0.08);
-    transition:all 0.3s ease;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
 }
 
-.faq-item:hover{
-    transform:translateY(-4px) scale(1.01);
-    box-shadow:0 20px 50px rgba(0,0,0,0.15);
+.faq-item:hover {
+    transform: translateY(-4px) scale(1.01);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
 }
 
 /* question */
-.faq-question{
-    width:100%;
-    padding:22px 24px;
-    border:none;
-    background:transparent;
+.faq-question {
+    width: 100%;
+    padding: 22px 24px;
+    border: none;
+    background: transparent;
 
-    font-size:16px;
-    font-weight:600;
+    font-size: 16px;
+    font-weight: 600;
 
-    display:flex;
-    justify-content:space-between;
-    align-items:center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
-    cursor:pointer;
+    cursor: pointer;
 }
 
 /* icon */
-.faq-question span{
-    width:32px;
-    height:32px;
+.faq-question span {
+    width: 32px;
+    height: 32px;
 
-    display:flex;
-    align-items:center;
-    justify-content:center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    background:#8d2123;
-    color:white;
+    background: #8d2123;
+    color: white;
 
-    border-radius:50%;
-    font-size:18px;
+    border-radius: 50%;
+    font-size: 18px;
 
-    transition:0.3s;
+    transition: 0.3s;
 }
 
 /* answer */
-.faq-answer{
-    max-height:0;
-    overflow:hidden;
+.faq-answer {
+    max-height: 0;
+    overflow: hidden;
 
-    transition:max-height 0.4s ease;
+    transition: max-height 0.4s ease;
 
-    padding:0 24px;
+    padding: 0 24px;
 }
 
-.faq-answer p{
-    padding:15px 0 20px;
-    color:#555;
-    line-height:1.6;
+.faq-answer p {
+    padding: 15px 0 20px;
+    color: #555;
+    line-height: 1.6;
 }
 
 /* active */
-.faq-item.active .faq-answer{
-    max-height:300px;
+.faq-item.active .faq-answer {
+    max-height: 300px;
 }
 
-.faq-item.active .faq-question span{
-    transform:rotate(45deg);
-    background:#6f1a1c;
+.faq-item.active .faq-question span {
+    transform: rotate(45deg);
+    background: #6f1a1c;
 }


### PR DESCRIPTION
## Title: Fixed(pte-test): replace hardcoded colors with CSS variables for theme support

**Closes:** #105 

**Summary**  
Refactors the PTE Test page to fully respect the global light/dark theme toggle by replacing all hardcoded colour values with the appropriate CSS variables from `theme.css`.

**Changes Made**
- **Sections** – Updated `background` properties for `.test-section`, `.test-section.light`, and `.test-section.dark-bg` to use `--bg-primary` and `--bg-secondary`.
- **Cards & Lists** – Refactored `.test-card` and `.centre-list` to use `--bg-card`, `--shadow-card`, `--border-card`, and `--border-input` for dynamic styling.
- **Text Elements** – Replaced static paragraph colours with `--text-secondary` and `--text-muted` to ensure proper contrast in both themes.
- **Inline Styles** – Removed or substituted any remaining inline colour declarations.

## Screenshot:
<img width="1907" height="877" alt="image" src="https://github.com/user-attachments/assets/f13dcede-19e4-4b3c-a4f3-2b36a7d680bd" />


**Testing**
- Toggled between light and dark modes to verify all sections, cards, and text render with correct contrast.
- Confirmed no visual regressions on desktop and mobile viewports.