### PR TITLE
Fix(uk): replace hardcoded colors with CSS variables for theme support

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -22,26 +22,21 @@
 </header>
 
 <main>
-
 <!-- HERO -->
-<section class="about-hero">
+<section class="about-hero" style="background-image: url('https://www.soccollege.uk/wp-content/uploads/2024/11/well-being-bg.jpg');">
+    <div class="hero-overlay"></div>
     <div class="hero-inner">
-
         <span class="hero-badge">
             <i class="fas fa-globe"></i> Trusted Worldwide
         </span>
-
         <h1>About PTE Academic</h1>
-
         <p>
             Fast, fair, and AI-powered English testing for global education and migration.
         </p>
-
         <div class="hero-actions">
             <button class="primary-btn">Check Availability</button>
             <a href="#about-section" class="hero-link">Learn More</a>
         </div>
-
     </div>
 </section>
 

--- a/pages/partners.html
+++ b/pages/partners.html
@@ -1,210 +1,450 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Partners & Research | PTE HUB</title>
 
-    <link rel="stylesheet" href="../styles/css/style.css">
-    <link rel="stylesheet" href="../styles/css/navbar.css">
-    <link rel="stylesheet" href="../styles/css/footer.css">
-    <link rel="stylesheet" href="../styles/css/partners.css">
-    <link rel="stylesheet" href="../styles/css/auth-popup.css">
+    <!-- Global Styles -->
+    <link rel="stylesheet" href="../styles/css/style.css" />
+    <link rel="stylesheet" href="../styles/css/navbar.css" />
+    <link rel="stylesheet" href="../styles/css/footer.css" />
+    <link rel="stylesheet" href="../styles/css/auth-popup.css" />
+    <link rel="stylesheet" href="../styles/css/theme.css" />
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
+
+    <!-- Theme initialisation -->
+    <script src="../scripts/js/theme.js"></script>
+
+    <style>
+        /* ===== HERO ===== */
+        .partners-hero {
+            position: relative;
+            background-image: url('/assets/images/partner-bg.avif');
+            background-size: cover;
+            background-position: center 30%;
+            min-height: 75vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            color: white;
+        }
+        .partners-hero::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, rgba(0,0,0,0.65), rgba(141,33,35,0.75));
+            z-index: 1;
+        }
+        .partners-hero .hero-inner {
+            position: relative;
+            z-index: 2;
+            max-width: 800px;
+            padding: 0 20px;
+        }
+        .partners-hero h1 {
+            font-size: clamp(2.4rem, 5vw, 3.5rem);
+            font-weight: 700;
+            margin-bottom: 15px;
+            text-shadow: 0 2px 15px rgba(0,0,0,0.4);
+        }
+        .partners-hero p {
+            font-size: clamp(1rem, 2vw, 1.2rem);
+            color: rgba(255,255,255,0.95);
+            max-width: 700px;
+            margin: 0 auto;
+            text-shadow: 0 1px 6px rgba(0,0,0,0.3);
+        }
+        .partners-hero .hero-actions {
+            margin-top: 30px;
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+        .partners-hero .primary-btn,
+        .partners-hero .secondary-btn {
+            display: inline-block;
+            padding: 12px 28px;
+            border-radius: 8px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: all 0.3s ease;
+            border: none;
+            cursor: pointer;
+        }
+        .partners-hero .primary-btn {
+            background: white;
+            color: #8d2123;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+        }
+        .partners-hero .primary-btn:hover {
+            transform: translateY(-3px);
+            background: #f0f0f0;
+        }
+        .partners-hero .secondary-btn {
+            background: transparent;
+            color: white;
+            border: 2px solid white;
+        }
+        .partners-hero .secondary-btn:hover {
+            background: rgba(255,255,255,0.1);
+            transform: translateY(-3px);
+        }
+
+        /* ===== SECTION OVERRIDES (use global .features-section etc.) ===== */
+        .partners-section {
+            padding: clamp(56px, 8vw, 96px) 20px;
+        }
+        .partners-section .section-heading {
+            text-align: center;
+            margin-bottom: 50px;
+        }
+        .partners-section .section-heading h2 {
+            font-size: clamp(1.75rem, 4vw, 2.5rem);
+            color: var(--text-primary);
+        }
+        .partners-section .section-heading p {
+            color: var(--text-muted);
+            max-width: 700px;
+            margin: 10px auto 0;
+        }
+
+        /* ===== PARTNER LOGOS ===== */
+        .logo-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 25px;
+            margin-top: 30px;
+        }
+        .logo-box {
+            background: var(--bg-card);
+            border: 1px solid var(--border-card);
+            border-radius: 12px;
+            padding: 25px 15px;
+            text-align: center;
+            box-shadow: var(--shadow-soft);
+            transition: all 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+        }
+        .logo-box:hover {
+            transform: translateY(-4px);
+            box-shadow: var(--shadow-lift);
+            border-color: var(--accent);
+        }
+        .logo-box i {
+            font-size: 2.2rem;
+            color: var(--accent);
+        }
+        .logo-box span {
+            font-weight: 600;
+            color: var(--text-primary);
+            font-size: 0.95rem;
+        }
+
+        /* ===== PUBLICATIONS LIST ===== */
+        .pub-list {
+            max-width: 850px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+        .pub-item {
+            background: var(--bg-card);
+            border: 1px solid var(--border-card);
+            border-radius: 12px;
+            padding: 20px 25px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 20px;
+            transition: all 0.3s ease;
+            box-shadow: var(--shadow-soft);
+        }
+        .pub-item:hover {
+            transform: translateY(-3px);
+            box-shadow: var(--shadow-lift);
+        }
+        .pub-info {
+            display: flex;
+            align-items: flex-start;
+            gap: 16px;
+            flex: 1;
+        }
+        .pub-info i {
+            font-size: 2rem;
+            color: var(--accent);
+            margin-top: 4px;
+        }
+        .pub-info h4 {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin: 0 0 4px 0;
+        }
+        .pub-info p {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+            margin: 0;
+            line-height: 1.5;
+        }
+        .download-btn {
+            background: transparent;
+            border: 1.5px solid var(--accent);
+            color: var(--accent);
+            padding: 8px 16px;
+            border-radius: 8px;
+            font-weight: 700;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: all 0.25s ease;
+            white-space: nowrap;
+        }
+        .download-btn:hover {
+            background: var(--accent);
+            color: white;
+            box-shadow: 0 6px 15px rgba(141,33,35,0.2);
+        }
+
+        /* ===== FUTURE INITIATIVES ===== */
+        .future-card {
+            background: var(--bg-card);
+            border-radius: 16px;
+            padding: 40px;
+            box-shadow: var(--shadow-soft);
+            border: 1px solid var(--border-card);
+            max-width: 900px;
+            margin: 0 auto;
+            display: flex;
+            gap: 40px;
+            align-items: center;
+            transition: all 0.3s ease;
+        }
+        .future-card:hover {
+            box-shadow: var(--shadow-lift);
+        }
+        .future-text {
+            flex: 1.5;
+        }
+        .future-text h2 {
+            font-size: clamp(1.3rem, 2.5vw, 1.8rem);
+            color: var(--text-primary);
+            margin-bottom: 12px;
+        }
+        .future-text p {
+            color: var(--text-muted);
+            line-height: 1.7;
+        }
+        .future-text ul {
+            list-style: none;
+            padding: 0;
+            margin-top: 20px;
+        }
+        .future-text ul li {
+            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: var(--text-secondary);
+            font-weight: 500;
+        }
+        .future-text ul li i {
+            color: var(--accent);
+        }
+        .future-icon {
+            flex: 0.5;
+            font-size: 4rem;
+            color: rgba(141,33,35,0.15);
+            text-align: center;
+        }
+
+        /* ===== RESPONSIVE ===== */
+        @media (max-width: 768px) {
+            .pub-item {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .download-btn {
+                width: 100%;
+                text-align: center;
+            }
+            .future-card {
+                flex-direction: column;
+                padding: 30px;
+            }
+            .future-icon {
+                font-size: 3rem;
+            }
+        }
+    </style>
 </head>
 
 <body>
 
+    <!-- ================= HEADER (NAVBAR) ================= -->
     <header id="header">
         <div id="navbar-placeholder"></div>
     </header>
 
     <main>
 
-        <!-- HERO -->
+        <!-- ================= HERO ================= -->
         <section class="partners-hero">
             <div class="hero-inner">
-                <div class="hero-content">
-                    <span class="hero-badge">
-                        <i class="fas fa-flask"></i> Scientific Innovation
-                    </span>
-                    <h1>Partners & Research</h1>
+                <h1>Partners &amp; Research</h1>
+                <p>
+                    PTE Academic's AI scoring models are backed by rigorous linguistic research,
+                    machine learning studies, and trusted partnerships worldwide.
+                </p>
+                <div class="hero-actions">
+                    <a href="#research" class="primary-btn">View Research</a>
+                    <a href="#partners" class="secondary-btn">Our Partners</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= RESEARCH COLLABORATIONS ================= -->
+        <section id="research" class="features-section reveal">
+            <div class="features-heading">
+                <h2>Research Collaborations</h2>
+                <p>We collaborate with global educational research bodies to advance machine learning scoring systems and cognitive language assessments.</p>
+            </div>
+            <div class="features-container">
+                <div class="feature-box">
+                    <i class="fas fa-brain"></i>
+                    <h3>AI Scoring Validity Study</h3>
+                    <p>A multi-year investigation proving that machine-graded responses correlate to a 0.96 coefficient with senior human examiners.</p>
+                </div>
+                <div class="feature-box">
+                    <i class="fas fa-language"></i>
+                    <h3>Acoustic Modeling across Accents</h3>
+                    <p>Deep neural networks in ASR ensure 100% scoring fairness across 120+ international regional accents.</p>
+                </div>
+                <div class="feature-box">
+                    <i class="fas fa-scale-balanced"></i>
+                    <h3>Assessment Equity &amp; Bias Elimination</h3>
+                    <p>Analyzing candidate data across genders and demographics to validate that automated testing eliminates subjective grading bias.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= ACADEMIC & INDUSTRY PARTNERS ================= -->
+        <section id="partners" class="features-section reveal" style="background:var(--bg-secondary);">
+            <div class="features-heading">
+                <h2>Our Global Network</h2>
+                <p>We work side-by-side with leading universities, research labs, and government bodies.</p>
+            </div>
+
+            <h3 style="text-align:center; margin-top:20px; color:var(--text-primary);">Academic Institutions &amp; Research Labs</h3>
+            <div class="logo-grid">
+                <div class="logo-box"><i class="fas fa-university"></i><span>Stanford Lang Lab</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Melbourne Language Inst</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Oxford Ling Dept</span></div>
+                <div class="logo-box"><i class="fas fa-university"></i><span>Toronto AI Centre</span></div>
+            </div>
+
+            <h3 style="text-align:center; margin-top:50px; color:var(--text-primary);">Industry &amp; Government Recognition</h3>
+            <div class="logo-grid">
+                <div class="logo-box"><i class="fas fa-passport"></i><span>Aussie Home Affairs</span></div>
+                <div class="logo-box"><i class="fas fa-passport"></i><span>IRCC Canada</span></div>
+                <div class="logo-box"><i class="fas fa-passport"></i><span>UK Home Office</span></div>
+                <div class="logo-box"><i class="fas fa-user-md"></i><span>Global Nursing Council</span></div>
+            </div>
+        </section>
+
+        <!-- ================= PUBLICATIONS & RESOURCES ================= -->
+        <section id="publications" class="features-section reveal">
+            <div class="features-heading">
+                <h2>Publications &amp; Resources</h2>
+                <p>Download official white papers, research reports, and technical manuals.</p>
+            </div>
+            <div class="pub-list">
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>PTE Academic Technical Manual v4.2</h4>
+                            <p>Comprehensive manual outlining scoring algorithms, standard error of measurement (SEM), and test security frameworks.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (4.2 MB)</button>
+                </div>
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>AI Scoring Validation and Reliability White Paper</h4>
+                            <p>Validation tests proving the alignment of automated assessment with human evaluation results.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (2.8 MB)</button>
+                </div>
+                <div class="pub-item">
+                    <div class="pub-info">
+                        <i class="far fa-file-pdf"></i>
+                        <div>
+                            <h4>PTE Score Concordance with IELTS and TOEFL</h4>
+                            <p>Official reference concordance charts mapping PTE Academic overall scores to corresponding IELTS and TOEFL levels.</p>
+                        </div>
+                    </div>
+                    <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> PDF (1.1 MB)</button>
+                </div>
+            </div>
+        </section>
+
+        <!-- ================= FUTURE INITIATIVES ================= -->
+        <section style="padding: clamp(56px, 8vw, 96px) 20px; background:var(--bg-secondary);">
+            <div class="future-card">
+                <div class="future-text">
+                    <h2>Future Initiatives</h2>
                     <p>
-                        PTE Academic's AI scoring models and assessments are backed by rigorous linguistic research, machine learning studies, and trusted partnerships worldwide.
+                        We are actively exploring next-generation testing methodologies, including adaptive cognitive testing
+                        and LLM-assisted grammar diagnostics, to deliver even faster, more precise, and highly personalised
+                        learning feedback.
                     </p>
-                    <div class="hero-actions">
-                        <a href="#research" class="primary-btn">View Research</a>
-                        <a href="#partners" class="secondary-btn">Our Partners</a>
-                    </div>
+                    <ul>
+                        <li><i class="fas fa-arrow-right"></i> Next-Gen LLM scoring models</li>
+                        <li><i class="fas fa-arrow-right"></i> Dynamic test questions custom-tailored to skill gaps</li>
+                        <li><i class="fas fa-arrow-right"></i> Free predictive scoring reports for low-income regions</li>
+                    </ul>
                 </div>
-                <div class="hero-mascot-container">
-                    <div class="mascot-speech-left">
-                        <p>Our AI-driven testing is scientifically validated to be 100% fair and unbiased!</p>
-                    </div>
-                    <img src="../assets/images/mascot.png" alt="PTE Hub Mascot" class="hero-mascot">
+                <div class="future-icon">
+                    <i class="fas fa-microchip"></i>
                 </div>
             </div>
         </section>
 
-        <!-- RESEARCH COLLABORATIONS -->
-        <section id="research" class="partners-section">
+        <!-- ================= CTA ================= -->
+        <section class="about-cta" style="margin-top:0;">
             <div class="container">
-                <h2 class="center-heading">Research Collaborations</h2>
-                <p class="section-subtitle">We collaborate with global educational research bodies to advance machine learning scoring systems and cognitive language assessments.</p>
-                
-                <div class="research-grid">
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-brain"></i></div>
-                        <h3>AI Scoring Validity Study</h3>
-                        <p>A multi-year investigation proving that machine-graded spoken and written responses correlate to a 0.96 coefficient with senior human examiners.</p>
-                        <span class="research-meta">Published: Journal of Educational Measurement (2025)</span>
-                    </div>
-
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-language"></i></div>
-                        <h3>Acoustic Modeling across Accents</h3>
-                        <p>Researching deep neural networks in automatic speech recognition to ensure 100% scoring fairness across 120+ international regional accents.</p>
-                        <span class="research-meta">Published: International Speech Communication Association (2025)</span>
-                    </div>
-
-                    <div class="research-card">
-                        <div class="research-card-icon"><i class="fas fa-scale-balanced"></i></div>
-                        <h3>Assessment Equity & Bias Elimination</h3>
-                        <p>Analyzing candidate data across genders and demographic origins to validate that computerized tests eliminate subjective grading bias.</p>
-                        <span class="research-meta">Published: Language Testing Quarterly (2026)</span>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ACADEMIC & INDUSTRY PARTNERS -->
-        <section id="partners" class="partners-section light">
-            <div class="container">
-                <h2 class="center-heading">Our Global Network</h2>
-                
-                <div class="network-tabs">
-                    <div class="network-tab-content">
-                        <h3>Academic Institutions & Research Labs</h3>
-                        <p class="network-desc">We work side-by-side with leading university language departments to align our curriculum and validate test frameworks.</p>
-                        
-                        <div class="partner-logos-grid">
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Stanford Lang Lab</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Melbourne Language Inst</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Oxford Ling Dept</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-university"></i>
-                                <span>Toronto AI Centre</span>
-                            </div>
-                        </div>
-
-                        <h3 class="margin-top-section">Industry & Government Recognition</h3>
-                        <p class="network-desc">Our assessments are recognized for immigration, border protection, and professional licensing in key destinations.</p>
-                        
-                        <div class="partner-logos-grid">
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>Aussie Home Affairs</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>IRCC Canada</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-passport"></i>
-                                <span>UK Home Office</span>
-                            </div>
-                            <div class="logo-box">
-                                <i class="fas fa-user-md"></i>
-                                <span>Global Nursing Council</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- PUBLICATIONS & RESOURCES -->
-        <section id="publications" class="partners-section">
-            <div class="container">
-                <h2 class="center-heading">Publications & Resources</h2>
-                <p class="section-subtitle">Download official white papers, research reports, and technical manuals detailing our exam structure and validation standards.</p>
-                
-                <div class="publications-list">
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>PTE Academic Technical Manual v4.2</h4>
-                                <p>Comprehensive manual outlining scoring algorithms, standard error of measurement (SEM), and test security frameworks.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (4.2 MB)</button>
-                    </div>
-
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>AI Scoring Validation and Reliability White Paper</h4>
-                                <p>A summary of validation tests proving the alignment of automated assessment with human evaluation results.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (2.8 MB)</button>
-                    </div>
-
-                    <div class="pub-item">
-                        <div class="pub-info">
-                            <i class="far fa-file-pdf pub-icon"></i>
-                            <div>
-                                <h4>PTE Score Concordance with IELTS and TOEFL</h4>
-                                <p>Official reference concordance charts mapping PTE Academic overall scores to corresponding IELTS and TOEFL levels.</p>
-                            </div>
-                        </div>
-                        <button class="download-btn" onclick="alert('Downloading Document...')"><i class="fas fa-download"></i> Download PDF (1.1 MB)</button>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- FUTURE INITIATIVES -->
-        <section class="future-initiatives-section">
-            <div class="container">
-                <div class="future-wrapper">
-                    <div class="future-text">
-                        <h2>Future Initiatives</h2>
-                        <p>We are actively exploring next-generation testing methodologies, including adaptive cognitive testing and LLM-assisted grammar diagnostics, to deliver even faster, more precise, and highly personalized learning feedback.</p>
-                        <ul class="future-points">
-                            <li><i class="fas fa-arrow-right"></i> Next-Gen LLM scoring models</li>
-                            <li><i class="fas fa-arrow-right"></i> Dynamic test questions custom-tailored to skill gaps</li>
-                            <li><i class="fas fa-arrow-right"></i> Free predictive scoring reports for low-income regions</li>
-                        </ul>
-                    </div>
-                    <div class="future-deco">
-                        <i class="fas fa-microchip future-icon"></i>
-                    </div>
-                </div>
+                <h2>Join Our Research Community</h2>
+                <p>Collaborate with us to shape the future of AI-driven language assessment.</p>
+                <button class="primary-btn" onclick="alert('Contact us at research@ptehub.com')">Get Involved</button>
             </div>
         </section>
 
     </main>
 
+    <!-- ================= FOOTER & POPUP PLACEHOLDERS ================= -->
     <div id="footer-placeholder"></div>
     <div id="auth-popup-placeholder"></div>
 
+    <!-- ================= SCRIPTS ================= -->
     <script src="../scripts/js/navbar.js"></script>
     <script src="../scripts/js/footer.js"></script>
     <script src="../scripts/js/script.js"></script>
     <script src="../scripts/js/auth-popup.js"></script>
+    <script src="../scripts/js/theme.js"></script>
 
 </body>
 </html>

--- a/pages/preparation.html
+++ b/pages/preparation.html
@@ -2,279 +2,231 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PTE Preparation | PTE HUB</title>
 
-    <!-- Global component styles (navbar, footer, auth-popup) -->
-    <link rel="stylesheet" href="../styles/css/navbar.css">
-    <link rel="stylesheet" href="../styles/css/footer.css">
-    <link rel="stylesheet" href="../styles/css/auth-popup.css">
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;600;700&display=swap"
-        rel="stylesheet">
+    <!-- Global Stylesheets -->
+    <link rel="stylesheet" href="../styles/css/style.css" />
+    <link rel="stylesheet" href="../styles/css/navbar.css" />
+    <link rel="stylesheet" href="../styles/css/footer.css" />
+    <link rel="stylesheet" href="../styles/css/auth-popup.css" />
+    <link rel="stylesheet" href="../styles/css/theme.css" />
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+
+    <!-- Theme initialisation -->
+    <script src="../scripts/js/theme.js"></script>
 
     <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            font-family: 'Titillium Web', sans-serif;
-        }
+        /* ===== PREPARATION PAGE CUSTOM STYLES ===== */
+        /* All colours use theme variables, so dark mode works automatically */
 
-        html {
-            scroll-behavior: smooth;
-        }
-
-        body {
-            background: #f8fafc;
-            color: #1f2937;
-            overflow-x: hidden;
-        }
-
-        /* ================= HERO ================= */
-
-        .hero {
+        .prep-hero {
             min-height: 75vh;
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             padding: 40px 20px;
-
             background:
-                linear-gradient(rgba(10, 15, 30, .72),
-                    rgba(10, 15, 30, .72)),
+                linear-gradient(rgba(10, 15, 30, 0.72),
+                    rgba(10, 15, 30, 0.72)),
                 url("https://images.unsplash.com/photo-1434030216411-0b793f4b4173");
-
             background-size: cover;
             background-position: center;
+            position: relative;
         }
 
-        .hero div {
+        .prep-hero div {
             max-width: 850px;
         }
 
-        .hero h1 {
+        .prep-hero h1 {
             color: #fff;
-            font-size: 4rem;
+            font-size: clamp(2.4rem, 6vw, 4rem);
             font-weight: 700;
             margin-bottom: 20px;
             line-height: 1.1;
         }
 
-        .hero p {
+        .prep-hero p {
             color: rgba(255, 255, 255, .9);
-            font-size: 1.2rem;
+            font-size: clamp(1rem, 2vw, 1.2rem);
             max-width: 700px;
             margin: auto;
         }
 
-        /* ================= COMMON ================= */
-
-        .features-section,
-        .section {
-            padding: 45px 8%;
+        /* Common sections */
+        .prep-section {
+            padding: 70px 8%;
         }
 
-        .features-heading,
-        .section-title {
+        .prep-section .section-heading {
             text-align: center;
             margin-bottom: 60px;
         }
 
-        .features-heading h2,
-        .section-title h2 {
-            font-size: 2.7rem;
-            color: #8d2123;
+        .prep-section .section-heading h2 {
+            font-size: clamp(2rem, 4vw, 2.7rem);
+            color: var(--accent, #8d2123);
             margin-bottom: 10px;
         }
 
-        .features-heading p,
-        .section-title p {
-            color: #6b7280;
+        .prep-section .section-heading p {
+            color: var(--text-muted, #6b7280);
             font-size: 1.05rem;
         }
 
-        .features-container {
+        .prep-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
             gap: 30px;
         }
 
-        .feature-box {
-            background: #fff;
+        .prep-card {
+            background: var(--bg-card, #fff);
             padding: 32px;
             border-radius: 22px;
-            transition: .35s ease;
+            transition: transform 0.35s ease, box-shadow 0.35s ease;
+            box-shadow: var(--shadow-soft, 0 10px 30px rgba(0, 0, 0, 0.08));
+            border: 1px solid var(--border-card, transparent);
         }
 
-        .feature-box h3 {
-            color: #111827;
+        .prep-card:hover {
+            transform: translateY(-8px);
+            box-shadow: var(--shadow-lift, 0 20px 40px rgba(0, 0, 0, 0.12));
+        }
+
+        .prep-card h3 {
+            color: var(--text-primary, #111827);
             margin-bottom: 10px;
             font-size: 1.35rem;
         }
 
-        .feature-box p {
-            color: #6b7280;
+        .prep-card p {
+            color: var(--text-muted, #6b7280);
             line-height: 1.7;
         }
 
-        .feature-box ul {
+        .prep-card ul {
             padding-left: 20px;
             margin-top: 15px;
         }
 
-        .feature-box li {
+        .prep-card li {
             margin-bottom: 8px;
-            color: #4b5563;
+            color: var(--text-secondary, #4b5563);
         }
 
-        /* ================= PRACTICE TESTS ================= */
-
-        #practice-tests .feature-box {
-            text-align: center;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, .08);
-        }
-
-        #practice-tests .feature-box:hover {
-            transform: translateY(-10px);
-        }
-
-        #practice-tests .feature-box i {
+        /* Practice tests – icon circles */
+        .prep-card .card-icon {
             width: 80px;
             height: 80px;
             margin: 0 auto 20px;
-
             display: flex;
             align-items: center;
             justify-content: center;
-
             border-radius: 50%;
-
-            background: linear-gradient(135deg,
-                    #8d2123,
-                    #d84a4d);
-
+            background: linear-gradient(135deg, var(--accent, #8d2123), #d84a4d);
             color: white;
             font-size: 2rem;
         }
 
-        /* ================= STUDY MATERIALS ================= */
-
-        #study-materials .feature-box {
-            border-left: 6px solid #8d2123;
+        /* Study materials – left border accent */
+        .prep-card.border-left {
+            border-left: 6px solid var(--accent, #8d2123);
             border-radius: 0 20px 20px 0;
-            box-shadow: 0 6px 20px rgba(0, 0, 0, .06);
         }
 
-        #study-materials .feature-box:hover {
-            transform: translateX(10px);
-        }
-
-        /* ================= TIPS ================= */
-
-        #tips-strategies .feature-box {
+        /* Tips & Strategies – gradient background (light theme) */
+        .prep-card.gradient-bg {
             background: linear-gradient(135deg,
-                    #fff 0%,
-                    #fff 55%,
-                    #f7dede 85%,
-                    #8d2123 200%);
-
-            border-radius: 20px;
-            color: #8d2123;
+                    var(--bg-card, #fff) 0%,
+                    var(--bg-card, #fff) 55%,
+                    rgba(141, 33, 35, 0.08) 85%,
+                    var(--accent, #8d2123) 200%);
+            color: var(--accent, #8d2123);
         }
 
-        #tips-strategies .feature-box h3 {
-            color: #8d2123;
+        .prep-card.gradient-bg h3,
+        .prep-card.gradient-bg p {
+            color: var(--accent, #8d2123);
         }
 
-        #tips-strategies .feature-box p {
-            color: #8d2123;
-        }
-
-        /* ================= MOCK TESTS ================= */
-
-        #mock-tests .feature-box {
+        /* Mock tests – left border with dot */
+        .prep-card.mock-card {
             position: relative;
-            border-left: 5px solid #8d2123;
+            border-left: 5px solid var(--accent, #8d2123);
             border-radius: 0 20px 20px 0;
             padding-left: 35px;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, .05);
         }
 
-        #mock-tests .feature-box::before {
+        .prep-card.mock-card::before {
             content: "";
             position: absolute;
-
             width: 18px;
             height: 18px;
-
-            background: #8d2123;
+            background: var(--accent, #8d2123);
             border-radius: 50%;
-
             left: -12px;
             top: 35px;
         }
 
-        /* ================= SAMPLE QUESTION ================= */
-
-        .feature-box[style] {
-            background: #fffef8;
-            border: 2px dashed #8d2123;
-            box-shadow: none;
+        /* Sample question card */
+        .prep-sample {
+            background: var(--bg-card, #fffef8);
+            border: 2px dashed var(--accent, #8d2123);
+            border-radius: 20px;
+            padding: 35px;
             max-width: 900px;
+            margin: 0 auto;
+            box-shadow: none;
         }
 
-        .feature-box[style] h3,
-        .feature-box[style] h4 {
-            color: #8d2123;
+        .prep-sample h3,
+        .prep-sample h4 {
+            color: var(--accent, #8d2123);
         }
 
-        .feature-box[style] p {
+        .prep-sample p {
             font-size: 1.05rem;
             line-height: 1.9;
+            color: var(--text-secondary, #4b5563);
         }
 
-        /* ================= STATS ================= */
-
-        .stats {
+        /* Stats cards */
+        .prep-stats {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
             gap: 25px;
         }
 
         .stat-card {
-            background:
-                linear-gradient(135deg,
-                    rgba(141, 33, 35, .95),
-                    rgba(204, 70, 74, .95));
-
+            background: linear-gradient(135deg,
+                    var(--accent, #8d2123),
+                    #d84a4d);
             color: white;
             text-align: center;
-
             padding: 45px 20px;
             border-radius: 25px;
-
             position: relative;
             overflow: hidden;
-
-            backdrop-filter: blur(12px);
         }
 
         .stat-card::after {
             content: "";
             position: absolute;
-
             width: 120px;
             height: 120px;
-
-            background: rgba(255, 255, 255, .08);
+            background: rgba(255, 255, 255, 0.08);
             border-radius: 50%;
-
             top: -30px;
             right: -30px;
         }
@@ -288,137 +240,164 @@
             opacity: .9;
         }
 
-        /* ================= FAQ ================= */
-
-        .gray {
-            background: #eef2f7;
-        }
-
-        .faq-item {
-            background: white;
+        /* FAQ items */
+        .prep-faq-item {
+            background: var(--bg-card, #fff);
             border-radius: 18px;
             margin-bottom: 18px;
             overflow: hidden;
-
-            box-shadow:
-                0 8px 25px rgba(0, 0, 0, .05);
+            box-shadow: var(--shadow-soft, 0 8px 25px rgba(0, 0, 0, 0.05));
+            border: 1px solid var(--border-card, transparent);
         }
 
-        .faq-question {
+        .prep-faq-question {
             width: 100%;
             border: none;
-
-            background: white;
-            color: #111827;
-
+            background: var(--bg-card, #fff);
+            color: var(--text-primary, #111827);
             text-align: left;
             padding: 22px;
-
             font-size: 1rem;
             font-weight: 600;
-
             cursor: pointer;
             position: relative;
+            transition: background 0.2s;
         }
 
-        .faq-question::after {
+        .prep-faq-question::after {
             content: "+";
             position: absolute;
             right: 25px;
-            color: #8d2123;
+            color: var(--accent, #8d2123);
             font-size: 1.4rem;
         }
 
-        .faq-answer {
+        .prep-faq-answer {
             display: none;
             padding: 0 22px 22px;
-            color: #6b7280;
+            color: var(--text-muted, #6b7280);
             line-height: 1.7;
         }
 
-        /* ================= CTA ================= */
+        .prep-faq-item.active .prep-faq-answer {
+            display: block;
+        }
 
-        .about-cta {
-            background:
-                linear-gradient(135deg,
-                    #8d2123,
-                    #b72d31);
+        .prep-faq-item.active .prep-faq-question::after {
+            content: "−";
+        }
 
+        /* CTA section */
+        .prep-cta {
+            background: linear-gradient(135deg, var(--accent, #8d2123), #b72d31);
             color: white;
             text-align: center;
             padding: 100px 8%;
         }
 
-        .about-cta h2 {
-            font-size: 2.8rem;
+        .prep-cta h2 {
+            font-size: clamp(2rem, 4vw, 2.8rem);
             margin-bottom: 15px;
         }
 
-        .about-cta p {
+        .prep-cta p {
             max-width: 700px;
             margin: auto;
             margin-bottom: 30px;
             opacity: .9;
         }
 
-        .mock-btn {
+        .prep-cta .mock-btn {
             display: inline-block;
             padding: 12px 24px;
-
             background: white;
-            color: #8d2123;
-
+            color: var(--accent, #8d2123);
             border-radius: 10px;
             text-decoration: none;
             font-weight: 700;
-
-            transition: .3s;
+            transition: transform 0.3s;
         }
 
-        .mock-btn:hover {
+        .prep-cta .mock-btn:hover {
             transform: translateY(-3px);
         }
 
-        /* ================= RESPONSIVE ================= */
-
-        @media(max-width:992px) {
-
-            .hero h1 {
-                font-size: 3rem;
+        /* Responsive */
+        @media (max-width: 768px) {
+            .prep-section {
+                padding: 60px 6%;
             }
-
-            .features-heading h2,
-            .section-title h2 {
-                font-size: 2.2rem;
+            .prep-card {
+                padding: 25px;
+            }
+            .prep-hero {
+                min-height: 60vh;
             }
         }
 
-        @media(max-width:768px) {
+        /* ================= DARK THEME OVERRIDES ================= */
+        [data-theme="dark"] body {
+            background: var(--bg-primary);
+            color: var(--text-primary);
+        }
 
-            .hero {
-                min-height: 60vh;
-            }
+        [data-theme="dark"] .features-heading h2,
+        [data-theme="dark"] .section-title h2 {
+            color: var(--text-primary);
+        }
 
-            .hero h1 {
-                font-size: 2.4rem;
-            }
+        [data-theme="dark"] .features-heading p,
+        [data-theme="dark"] .section-title p {
+            color: var(--text-secondary);
+        }
 
-            .hero p {
-                font-size: 1rem;
-            }
+        [data-theme="dark"] .feature-box {
+            background: var(--bg-card);
+        }
 
-            .features-section,
-            .section {
-                padding: 70px 6%;
-            }
+        [data-theme="dark"] .feature-box h3 {
+            color: var(--text-primary);
+        }
 
-            .feature-box {
-                padding: 25px;
-            }
+        [data-theme="dark"] .feature-box p,
+        [data-theme="dark"] .feature-box li {
+            color: var(--text-secondary);
+        }
 
-            .about-cta h2 {
-                font-size: 2rem;
-            }
+        [data-theme="dark"] #tips-strategies .feature-box {
+            background: var(--bg-card);
+        }
+
+        [data-theme="dark"] #tips-strategies .feature-box h3,
+        [data-theme="dark"] #tips-strategies .feature-box p {
+            color: var(--text-primary);
+        }
+
+        [data-theme="dark"] .feature-box[style] {
+            background: var(--bg-card) !important;
+            border-color: var(--border-card) !important;
+        }
+
+        [data-theme="dark"] .feature-box[style] h3,
+        [data-theme="dark"] .feature-box[style] h4 {
+            color: var(--text-primary) !important;
+        }
+
+        [data-theme="dark"] .gray {
+            background: var(--bg-secondary);
+        }
+
+        [data-theme="dark"] .faq-item {
+            background: var(--bg-card);
+        }
+
+        [data-theme="dark"] .faq-question {
+            background: var(--bg-card);
+            color: var(--text-primary);
+        }
+
+        [data-theme="dark"] .faq-answer {
+            color: var(--text-secondary);
         }
     </style>
 </head>
@@ -430,8 +409,8 @@
         <div id="navbar-placeholder"></div>
     </header>
 
-    <!-- HERO -->
-    <section class="hero">
+    <!-- ================= HERO ================= -->
+    <section class="prep-hero">
         <div>
             <h1>Prepare for PTE Success</h1>
             <p>
@@ -441,166 +420,110 @@
         </div>
     </section>
 
-    <!-- PRACTICE TESTS -->
-    <section id="practice-tests" class="features-section">
-
-        <div class="features-heading">
+    <!-- ================= PRACTICE TESTS ================= -->
+    <section id="practice-tests" class="prep-section">
+        <div class="section-heading">
             <h2>Practice Tests</h2>
             <p>Practice every section of the PTE Academic exam.</p>
         </div>
 
-        <div class="features-container">
-
-            <div class="feature-box">
-                <i class="fas fa-microphone"></i>
+        <div class="prep-grid">
+            <div class="prep-card">
+                <div class="card-icon"><i class="fas fa-microphone"></i></div>
                 <h3>Speaking</h3>
-                <p>
-                    Read Aloud, Repeat Sentence, Describe Image,
-                    Retell Lecture and Answer Short Question.
-                </p>
+                <p>Read Aloud, Repeat Sentence, Describe Image, Retell Lecture and Answer Short Question.</p>
             </div>
 
-            <div class="feature-box">
-                <i class="fas fa-pen"></i>
+            <div class="prep-card">
+                <div class="card-icon"><i class="fas fa-pen"></i></div>
                 <h3>Writing</h3>
-                <p>
-                    Summarize Written Text and Essay Writing
-                    practice with sample responses.
-                </p>
+                <p>Summarize Written Text and Essay Writing practice with sample responses.</p>
             </div>
 
-            <div class="feature-box">
-                <i class="fas fa-book-open"></i>
+            <div class="prep-card">
+                <div class="card-icon"><i class="fas fa-book-open"></i></div>
                 <h3>Reading</h3>
-                <p>
-                    Fill in the Blanks, Reorder Paragraphs
-                    and Multiple Choice questions.
-                </p>
+                <p>Fill in the Blanks, Reorder Paragraphs and Multiple Choice questions.</p>
             </div>
 
-            <div class="feature-box">
-                <i class="fas fa-headphones"></i>
+            <div class="prep-card">
+                <div class="card-icon"><i class="fas fa-headphones"></i></div>
                 <h3>Listening</h3>
-                <p>
-                    Summarize Spoken Text, Highlight Incorrect Words
-                    and Listening exercises.
-                </p>
+                <p>Summarize Spoken Text, Highlight Incorrect Words and Listening exercises.</p>
             </div>
-
         </div>
-
     </section>
 
-    <!-- STUDY MATERIAL -->
-    <section id="study-materials" class="features-section">
-
-        <div class="features-heading">
+    <!-- ================= STUDY MATERIALS ================= -->
+    <section id="study-materials" class="prep-section" style="background:var(--bg-secondary, #f8fafc);">
+        <div class="section-heading">
             <h2>Study Materials</h2>
             <p>Essential resources to strengthen your preparation.</p>
         </div>
 
-        <div class="features-container">
-
-            <div class="feature-box">
+        <div class="prep-grid">
+            <div class="prep-card border-left">
                 <h3>Grammar Guide</h3>
-                <p>
-                    Improve sentence structure, tenses,
-                    punctuation and accuracy.
-                </p>
+                <p>Improve sentence structure, tenses, punctuation and accuracy.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card border-left">
                 <h3>Vocabulary Lists</h3>
-                <p>
-                    Frequently used academic words and
-                    high-scoring vocabulary.
-                </p>
+                <p>Frequently used academic words and high-scoring vocabulary.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card border-left">
                 <h3>Essay Templates</h3>
-                <p>
-                    Proven essay structures for
-                    opinion and discussion tasks.
-                </p>
+                <p>Proven essay structures for opinion and discussion tasks.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card border-left">
                 <h3>Speaking Templates</h3>
-                <p>
-                    Frameworks for Describe Image,
-                    Retell Lecture and other tasks.
-                </p>
+                <p>Frameworks for Describe Image, Retell Lecture and other tasks.</p>
             </div>
-
         </div>
-
     </section>
 
-    <!-- TIPS -->
-    <section id="tips-strategies" class="features-section">
-
-        <div class="features-heading">
-            <h2>Tips & Strategies</h2>
+    <!-- ================= TIPS & STRATEGIES ================= -->
+    <section id="tips-strategies" class="prep-section">
+        <div class="section-heading">
+            <h2>Tips &amp; Strategies</h2>
         </div>
 
-        <div class="features-container">
-
-            <div class="feature-box">
+        <div class="prep-grid">
+            <div class="prep-card gradient-bg">
                 <h3>Time Management</h3>
-                <p>
-                    Allocate time wisely and avoid
-                    spending too long on a single question.
-                </p>
+                <p>Allocate time wisely and avoid spending too long on a single question.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card gradient-bg">
                 <h3>Speaking Strategy</h3>
-                <p>
-                    Focus on fluency and pronunciation
-                    rather than speaking too quickly.
-                </p>
+                <p>Focus on fluency and pronunciation rather than speaking too quickly.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card gradient-bg">
                 <h3>Writing Strategy</h3>
-                <p>
-                    Follow a clear introduction,
-                    body and conclusion structure.
-                </p>
+                <p>Follow a clear introduction, body and conclusion structure.</p>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card gradient-bg">
                 <h3>Listening Strategy</h3>
-                <p>
-                    Take notes efficiently and identify
-                    keywords while listening.
-                </p>
+                <p>Take notes efficiently and identify keywords while listening.</p>
             </div>
-
         </div>
-
     </section>
 
-    <!-- MOCK TESTS -->
-    <section id="mock-tests" class="features-section">
-
-        <div class="features-heading">
+    <!-- ================= MOCK TEST PATTERN ================= -->
+    <section id="mock-tests" class="prep-section" style="background:var(--bg-secondary, #f8fafc);">
+        <div class="section-heading">
             <h2>Mock Test Pattern</h2>
-            <p>
-                Understand the structure of a full-length
-                PTE Academic mock test.
-            </p>
+            <p>Understand the structure of a full-length PTE Academic mock test.</p>
         </div>
 
-        <div class="features-container">
-
-            <div class="feature-box">
-                <h3>Speaking & Writing</h3>
-                <p>
-                    Duration: 54–67 minutes
-                </p>
-
+        <div class="prep-grid">
+            <div class="prep-card mock-card">
+                <h3>Speaking &amp; Writing</h3>
+                <p>Duration: 54–67 minutes</p>
                 <ul>
                     <li>Read Aloud</li>
                     <li>Repeat Sentence</li>
@@ -609,9 +532,8 @@
                 </ul>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card mock-card">
                 <h3>Reading</h3>
-
                 <ul>
                     <li>Multiple Choice</li>
                     <li>Reorder Paragraphs</li>
@@ -619,113 +541,93 @@
                 </ul>
             </div>
 
-            <div class="feature-box">
+            <div class="prep-card mock-card">
                 <h3>Listening</h3>
-
                 <ul>
                     <li>Summarize Spoken Text</li>
                     <li>Highlight Incorrect Words</li>
                     <li>Write From Dictation</li>
                 </ul>
             </div>
-
         </div>
-
     </section>
 
-    <!-- STATS -->
-    <section class="section">
-        <div class="section-title">
+    <!-- ================= STATISTICS ================= -->
+    <section class="prep-section">
+        <div class="section-heading">
             <h2>Preparation Statistics</h2>
         </div>
 
-        <div class="stats">
-
+        <div class="prep-stats">
             <div class="stat-card">
                 <h2>500+</h2>
                 <p>Practice Questions</p>
             </div>
-
             <div class="stat-card">
                 <h2>50+</h2>
                 <p>Study Resources</p>
             </div>
-
             <div class="stat-card">
                 <h2>10K+</h2>
                 <p>Practice Sessions</p>
             </div>
-
             <div class="stat-card">
                 <h2>95%</h2>
                 <p>Student Satisfaction</p>
             </div>
-
         </div>
     </section>
 
-    <!-- FAQ -->
-    <section class="section gray">
-        <div class="section-title">
+    <!-- ================= FAQ ================= -->
+    <section class="prep-section" style="background:var(--bg-secondary, #eef2f7);">
+        <div class="section-heading">
             <h2>Preparation FAQs</h2>
         </div>
 
-        <div class="faq-item">
-            <button class="faq-question">How long should I prepare for PTE?</button>
-            <div class="faq-answer">
-                Most students prepare for 4-8 weeks depending on their English proficiency level.
+        <div style="max-width:800px;margin:0 auto;">
+            <div class="prep-faq-item">
+                <button class="prep-faq-question">How long should I prepare for PTE?</button>
+                <div class="prep-faq-answer">Most students prepare for 4–8 weeks depending on their English proficiency level.</div>
+            </div>
+
+            <div class="prep-faq-item">
+                <button class="prep-faq-question">Are mock tests important?</button>
+                <div class="prep-faq-answer">Yes, mock tests help you understand timing and exam patterns.</div>
             </div>
         </div>
-
-        <div class="faq-item">
-            <button class="faq-question">Are mock tests important?</button>
-            <div class="faq-answer">
-                Yes, mock tests help you understand timing and exam patterns.
-            </div>
-        </div>
-
     </section>
 
-    <!-- SAMPLE QUESTION -->
-    <section class="features-section">
-
-        <div class="features-heading">
+    <!-- ================= SAMPLE QUESTION ================= -->
+    <section class="prep-section">
+        <div class="section-heading">
             <h2>Sample Question</h2>
         </div>
 
-        <div class="feature-box" style="max-width:900px;margin:auto;">
-
+        <div class="prep-sample">
             <h3>Read Aloud Example</h3>
-
             <p>
                 Renewable energy sources are becoming increasingly
                 important as countries seek sustainable alternatives
                 to fossil fuels...
             </p>
-
-            <br>
-
+            <br />
             <h4>Tips</h4>
-
             <ul>
                 <li>Maintain a steady pace.</li>
                 <li>Avoid long pauses.</li>
                 <li>Focus on pronunciation and fluency.</li>
             </ul>
-
         </div>
-
     </section>
 
-    <!-- CTA -->
-    <section class="about-cta">
-        <div class="container">
+    <!-- ================= CTA ================= -->
+    <section class="prep-cta">
+        <div>
             <h2>Ready to Achieve Your Target PTE Score?</h2>
             <p>
                 Access practice tests, study materials, expert strategies
                 and mock exams in one place.
             </p>
-
             <a href="/pages/register.html" class="mock-btn">
                 Start Preparing
             </a>
@@ -741,13 +643,21 @@
     <script src="../scripts/js/footer.js"></script>
     <script src="../scripts/js/script.js"></script>
     <script src="../scripts/js/auth-popup.js"></script>
+    <script src="../scripts/js/theme.js"></script>
 
-    <!-- Existing FAQ toggle script -->
+    <!-- FAQ toggle (replicates original behaviour) -->
     <script>
-        document.querySelectorAll(".faq-question").forEach(btn => {
-            btn.addEventListener("click", () => {
-                const answer = btn.nextElementSibling;
-                answer.style.display = answer.style.display === "block" ? "none" : "block";
+        document.querySelectorAll('.prep-faq-question').forEach(btn => {
+            btn.addEventListener('click', function() {
+                const item = this.closest('.prep-faq-item');
+                const isActive = item.classList.contains('active');
+
+                // Close all others (accordion behaviour)
+                document.querySelectorAll('.prep-faq-item').forEach(i => i.classList.remove('active'));
+
+                if (!isActive) {
+                    item.classList.add('active');
+                }
             });
         });
     </script>

--- a/pages/pte-test.html
+++ b/pages/pte-test.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,6 +26,7 @@
             text-align: center;
             color: white;
         }
+
         .test-hero::before {
             content: "";
             position: absolute;
@@ -32,39 +34,46 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(135deg, rgba(0,0,0,0.65), rgba(141,33,35,0.75));
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.65), rgba(141, 33, 35, 0.75));
             z-index: 1;
         }
+
         .test-hero .hero-inner {
             position: relative;
             z-index: 2;
             max-width: 800px;
             padding: 0 20px;
         }
+
         .test-hero h1 {
             font-size: 52px;
             margin-bottom: 20px;
             font-weight: 700;
-            text-shadow: 0 2px 15px rgba(0,0,0,0.4);
+            text-shadow: 0 2px 15px rgba(0, 0, 0, 0.4);
         }
+
         .test-hero p {
             font-size: 22px;
-            color: rgba(255,255,255,0.95);
+            color: rgba(255, 255, 255, 0.95);
             max-width: 700px;
             margin: 0 auto;
-            text-shadow: 0 1px 6px rgba(0,0,0,0.3);
+            text-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
         }
+
         .test-section {
             padding: 80px 20px;
             text-align: center;
-            background: #ffffff;
+            background: var(--bg-primary);
         }
+
         .test-section.light {
-            background: #f8f9fc;
+            background: var(--bg-secondary);
         }
+
         .test-section.dark-bg {
-            background: linear-gradient(120deg, #f0f2f5, #ffffff);
+            background: linear-gradient(120deg, var(--bg-secondary), var(--bg-primary));
         }
+
         .test-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -72,33 +81,39 @@
             max-width: 1200px;
             margin: 40px auto 0;
         }
+
         .test-card {
-            background: white;
+            background: var(--bg-card);
             padding: 30px 20px;
             border-radius: 20px;
-            box-shadow: 0 12px 28px rgba(0,0,0,0.08);
+            box-shadow: var(--shadow-card);
             transition: 0.3s ease;
             backdrop-filter: blur(2px);
-            border: 1px solid rgba(255,255,255,0.3);
+            border: 1px solid var(--border-card);
         }
+
         .test-card:hover {
             transform: translateY(-6px);
-            box-shadow: 0 24px 48px rgba(141,33,35,0.15);
+            box-shadow: 0 24px 48px rgba(141, 33, 35, 0.15);
         }
+
         .test-card i {
             font-size: 42px;
             color: #8d2123;
             margin-bottom: 18px;
         }
+
         .test-card h3 {
             font-size: 22px;
             margin-bottom: 12px;
         }
+
         .test-card p {
-            color: #555;
+            color: var(--text-muted);
             font-size: 14px;
             line-height: 1.6;
         }
+
         .score-badge {
             display: inline-block;
             background: #8d2123;
@@ -109,28 +124,32 @@
             margin: 20px 0 10px;
             letter-spacing: 1px;
         }
+
         .centre-list {
-            background: white;
+            background: var(--bg-card);
             border-radius: 20px;
             padding: 20px 35px;
             max-width: 800px;
             margin: 30px auto 0;
             text-align: left;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.05);
+            box-shadow: var(--shadow-card);
         }
+
         .centre-list li {
             padding: 12px 0;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-input);
             display: flex;
             align-items: center;
             gap: 14px;
             font-size: 15px;
         }
+
         .centre-list li i {
             color: #8d2123;
             width: 26px;
             font-size: 18px;
         }
+
         .btn-secondary {
             background: #8d2123;
             color: white;
@@ -142,23 +161,39 @@
             cursor: pointer;
             transition: 0.25s;
             margin-top: 32px;
-            box-shadow: 0 4px 12px rgba(141,33,35,0.3);
+            box-shadow: 0 4px 12px rgba(141, 33, 35, 0.3);
         }
+
         .btn-secondary:hover {
             background: #6f1a1c;
             transform: translateY(-3px);
-            box-shadow: 0 8px 20px rgba(141,33,35,0.4);
+            box-shadow: 0 8px 20px rgba(141, 33, 35, 0.4);
         }
+
         @media (max-width: 768px) {
-            .test-hero h1 { font-size: 32px; }
-            .test-hero p { font-size: 18px; }
-            .centre-list li { flex-wrap: wrap; gap: 8px; }
-            .test-hero { min-height: 70vh; }
+            .test-hero h1 {
+                font-size: 32px;
+            }
+
+            .test-hero p {
+                font-size: 18px;
+            }
+
+            .centre-list li {
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .test-hero {
+                min-height: 70vh;
+            }
         }
+
         .test-section.light {
-            background-image: radial-gradient(circle at 10% 20%, rgba(141,33,35,0.02) 2%, transparent 2.5%);
+            background-image: radial-gradient(circle at 10% 20%, rgba(141, 33, 35, 0.02) 2%, transparent 2.5%);
             background-size: 28px 28px;
         }
+
         /* Offset for fixed navbar */
         section[id] {
             scroll-margin-top: 90px;
@@ -167,114 +202,118 @@
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
 </head>
+
 <body>
 
-<header id="header">
-    <div id="navbar-placeholder"></div>
-</header>
+    <header id="header">
+        <div id="navbar-placeholder"></div>
+    </header>
 
-<main>
+    <main>
 
-    <!-- Hero Section -->
-    <section class="test-hero">
-        <div class="hero-inner">
-            <h1>PTE Academic - The Smarter English Test</h1>
-            <p>Fully computer-based, AI-scored, and trusted by governments & universities worldwide.</p>
-        </div>
-    </section>
+        <!-- Hero Section -->
+        <section class="test-hero">
+            <div class="hero-inner">
+                <h1>PTE Academic - The Smarter English Test</h1>
+                <p>Fully computer-based, AI-scored, and trusted by governments & universities worldwide.</p>
+            </div>
+        </section>
 
-    <!-- What is PTE? (ID added) -->
-    <section id="what-is-pte" class="test-section dark-bg">
-        <div class="container" style="max-width: 900px; margin: auto;">
-            <h2>What is PTE Academic?</h2>
-            <p style="font-size: 18px; color: #444; max-width: 750px; margin: 20px auto;">
-                PTE Academic assesses real-life English communication skills. It uses AI to deliver fair,
-                unbiased results – often within 48 hours. No human bias, no unexpected surprises.
+        <!-- What is PTE? (ID added) -->
+        <section id="what-is-pte" class="test-section dark-bg">
+            <div class="container" style="max-width: 900px; margin: auto;">
+                <h2>What is PTE Academic?</h2>
+                <p style="font-size: 18px; color: var(--text-secondary); max-width: 750px; margin: 20px auto;">
+                    PTE Academic assesses real-life English communication skills. It uses AI to deliver fair,
+                    unbiased results – often within 48 hours. No human bias, no unexpected surprises.
+                </p>
+            </div>
+        </section>
+
+        <!-- Test Format (ID added) -->
+        <section id="test-format" class="test-section light">
+            <h2>Test Format</h2>
+            <p style="color: var(--text-muted); max-width: 700px; margin: 0 auto 20px;">The exam takes ~2 hours and
+                includes 20 different task types.</p>
+            <div class="test-grid">
+                <div class="test-card">
+                    <i class="fas fa-microphone-alt"></i>
+                    <h3>Speaking & Writing</h3>
+                    <p>Read aloud, repeat sentences, describe image, summarize text – 54–67 min.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-book-open"></i>
+                    <h3>Reading</h3>
+                    <p>Multiple choice, reorder paragraphs, fill in the blanks – 29–30 min.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-headphones"></i>
+                    <h3>Listening</h3>
+                    <p>Summarize spoken text, highlight incorrect words, write from dictation – 30–43 min.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scoring System (ID added) -->
+        <section id="scoring-system" class="test-section dark-bg">
+            <h2>Scoring System</h2>
+            <div class="score-badge">Overall score range: 10 – 90</div>
+            <p style="max-width: 750px; margin: 15px auto; color: var(--text-muted);">
+                PTE uses <strong>automated scoring</strong> based on thousands of real test-takers. Each skill (grammar,
+                oral fluency, pronunciation, spelling, vocabulary, written discourse) is scored individually.
+                Results are typically available <strong>within 48 hours</strong>.
             </p>
-        </div>
-    </section>
-
-    <!-- Test Format (ID added) -->
-    <section id="test-format" class="test-section light">
-        <h2>Test Format</h2>
-        <p style="color: #555; max-width: 700px; margin: 0 auto 20px;">The exam takes ~2 hours and includes 20 different task types.</p>
-        <div class="test-grid">
-            <div class="test-card">
-                <i class="fas fa-microphone-alt"></i>
-                <h3>Speaking & Writing</h3>
-                <p>Read aloud, repeat sentences, describe image, summarize text – 54–67 min.</p>
+            <div class="test-grid" style="margin-top: 30px;">
+                <div class="test-card">
+                    <i class="fas fa-chart-line"></i>
+                    <h3>Enabling Skills</h3>
+                    <p>Grammar, oral fluency, pronunciation, spelling, vocabulary.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-crosshairs"></i>
+                    <h3>Communicative Skills</h3>
+                    <p>Listening, Reading, Speaking, Writing – each scored 10–90.</p>
+                </div>
+                <div class="test-card">
+                    <i class="fas fa-clock"></i>
+                    <h3>Fast Reporting</h3>
+                    <p>Scores sent to unlimited institutions for free.</p>
+                </div>
             </div>
-            <div class="test-card">
-                <i class="fas fa-book-open"></i>
-                <h3>Reading</h3>
-                <p>Multiple choice, reorder paragraphs, fill in the blanks – 29–30 min.</p>
+        </section>
+
+        <!-- Test Centers (ID added) -->
+        <section id="test-centers" class="test-section light">
+            <h2>PTE Test Centres</h2>
+            <p>Authorised centres worldwide – find one near you.</p>
+            <div class="centre-list">
+                <li><i class="fas fa-map-marker-alt"></i> <strong>New Delhi, India</strong> – Connaught Place</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Melbourne, Australia</strong> – CBD, near Flinders St
+                </li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>London, UK</strong> – Holborn Centre</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Toronto, Canada</strong> – Yonge Street</li>
+                <li><i class="fas fa-map-marker-alt"></i> <strong>Auckland, New Zealand</strong> – Queen Street</li>
             </div>
-            <div class="test-card">
-                <i class="fas fa-headphones"></i>
-                <h3>Listening</h3>
-                <p>Summarize spoken text, highlight incorrect words, write from dictation – 30–43 min.</p>
-            </div>
-        </div>
-    </section>
+            <button class="btn-secondary" id="findCentreBtn">Find a Test Centre →</button>
+        </section>
 
-    <!-- Scoring System (ID added) -->
-    <section id="scoring-system" class="test-section dark-bg">
-        <h2>Scoring System</h2>
-        <div class="score-badge">Overall score range: 10 – 90</div>
-        <p style="max-width: 750px; margin: 15px auto; color: #555;">
-            PTE uses <strong>automated scoring</strong> based on thousands of real test-takers. Each skill (grammar,
-            oral fluency, pronunciation, spelling, vocabulary, written discourse) is scored individually.
-            Results are typically available <strong>within 48 hours</strong>.
-        </p>
-        <div class="test-grid" style="margin-top: 30px;">
-            <div class="test-card">
-                <i class="fas fa-chart-line"></i>
-                <h3>Enabling Skills</h3>
-                <p>Grammar, oral fluency, pronunciation, spelling, vocabulary.</p>
-            </div>
-            <div class="test-card">
-                <i class="fas fa-crosshairs"></i>
-                <h3>Communicative Skills</h3>
-                <p>Listening, Reading, Speaking, Writing – each scored 10–90.</p>
-            </div>
-            <div class="test-card">
-                <i class="fas fa-clock"></i>
-                <h3>Fast Reporting</h3>
-                <p>Scores sent to unlimited institutions for free.</p>
-            </div>
-        </div>
-    </section>
+    </main>
 
-    <!-- Test Centers (ID added) -->
-    <section id="test-centers" class="test-section light">
-        <h2>PTE Test Centres</h2>
-        <p>Authorised centres worldwide – find one near you.</p>
-        <div class="centre-list">
-            <li><i class="fas fa-map-marker-alt"></i> <strong>New Delhi, India</strong> – Connaught Place</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Melbourne, Australia</strong> – CBD, near Flinders St</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>London, UK</strong> – Holborn Centre</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Toronto, Canada</strong> – Yonge Street</li>
-            <li><i class="fas fa-map-marker-alt"></i> <strong>Auckland, New Zealand</strong> – Queen Street</li>
-        </div>
-        <button class="btn-secondary" id="findCentreBtn">Find a Test Centre →</button>
-    </section>
+    <div id="footer-placeholder"></div>
+    <div id="auth-popup-placeholder"></div>
 
-</main>
+    <script src="../scripts/js/navbar.js"></script>
+    <script src="../scripts/js/footer.js"></script>
+    <script src="../scripts/js/theme.js"></script>
+    <script src="../scripts/js/script.js"></script>
+    <script src="../scripts/js/auth-popup.js"></script>
 
-<div id="footer-placeholder"></div>
-<div id="auth-popup-placeholder"></div>
-
-<script src="../scripts/js/navbar.js"></script>
-<script src="../scripts/js/footer.js"></script>
-<script src="../scripts/js/theme.js"></script>
-<script src="../scripts/js/script.js"></script>
-<script src="../scripts/js/auth-popup.js"></script>
-
-<script>
-    document.getElementById('findCentreBtn')?.addEventListener('click', () => {
-        alert('Full test centre locator coming soon. Visit the official PTE website for the latest list.');
-    });
-</script>
+    <script>
+        document.getElementById('findCentreBtn')?.addEventListener('click', () => {
+            alert('Full test centre locator coming soon. Visit the official PTE website for the latest list.');
+        });
+    </script>
 
 </body>
+
 </html>

--- a/scripts/js/auth-popup.js
+++ b/scripts/js/auth-popup.js
@@ -9,6 +9,8 @@ document.addEventListener("DOMContentLoaded", () => {
             const container = document.getElementById("auth-popup-placeholder");
             if(container){
                 container.innerHTML = data;
+
+
             }
         });
 

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -4,34 +4,34 @@ const isSubpage = window.location.pathname.includes('/pages/');
 const footerPath = isSubpage ? '../components/footer.html' : 'components/footer.html';
 
 fetch(footerPath)
-.then(response => response.text())
-.then(data => {
+  .then(response => response.text())
+  .then(data => {
 
-  document.getElementById("footer-placeholder").innerHTML = data;
+    document.getElementById("footer-placeholder").innerHTML = data;
 
-  // Newsletter form functionality
+    // Newsletter form functionality
 
-  const form = document.getElementById("newsletter-form");
+    const form = document.getElementById("newsletter-form");
 
-  if(form){
+    if (form) {
 
-    form.addEventListener("submit", function(e){
+      form.addEventListener("submit", function (e) {
 
-      e.preventDefault();
+        e.preventDefault();
 
-      const email = document.getElementById("newsletter-email").value;
+        const email = document.getElementById("newsletter-email").value;
 
-      if(email.trim() === ""){
-        alert("Please enter a valid email.");
-        return;
-      }
+        if (email.trim() === "") {
+          alert("Please enter a valid email.");
+          return;
+        }
 
-      alert("Thank you for subscribing!");
+        alert("Thank you for subscribing!");
 
-      form.reset();
+        form.reset();
 
-    });
+      });
 
-  }
+    }
 
-});
+  });

--- a/scripts/js/navbar.js
+++ b/scripts/js/navbar.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", function () {
 
-    fetch("../components/navbar.html")
+    const isSubpage = window.location.pathname.includes('/pages/');
+    const navbarPath = isSubpage ? '../components/navbar.html' : 'components/navbar.html';
+
+    fetch(navbarPath)
         .then(response => response.text())
         .then(data => {
         
@@ -9,6 +12,8 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!placeholder) return;
         
             placeholder.innerHTML = data;
+
+
 
         const hamburger = document.getElementById("hamburger");
         const navbar = document.getElementById("navbar");

--- a/styles/css/australia.css
+++ b/styles/css/australia.css
@@ -9,9 +9,9 @@
 
 body {
     font-family: 'Arial', sans-serif;
-    color: #1a1a1a;
+    color: var(--text-primary);
     line-height: 1.6;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 /* Section Container */
@@ -30,14 +30,14 @@ body {
 .section-header h2 {
     font-size: 38px;
     font-weight: 700;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 15px;
     letter-spacing: -0.5px;
 }
 
 .section-header p {
     font-size: 17px;
-    color: #555;
+    color: var(--text-muted);
     max-width: 700px;
     margin: 0 auto;
     line-height: 1.65;
@@ -118,8 +118,8 @@ body {
 /* ===== QUICK NAVIGATION MENU ===== */
 
 .quick-nav {
-    background: white;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    background: var(--bg-card);
+    box-shadow: var(--shadow-soft);
     padding: 30px 20px;
     position: sticky;
     top: 0;
@@ -134,7 +134,7 @@ body {
 .quick-nav-title {
     font-size: 18px;
     font-weight: 700;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
     display: flex;
     align-items: center;
@@ -156,8 +156,8 @@ body {
     align-items: center;
     gap: 8px;
     padding: 10px 16px;
-    background: #f7f7f7;
-    color: #1a1a1a;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
     text-decoration: none;
     border-radius: 8px;
     font-size: 14px;
@@ -167,10 +167,10 @@ body {
 }
 
 .quick-nav-list a:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateY(-3px);
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 .quick-nav-list i {
@@ -238,9 +238,9 @@ body {
 
 /* Active link highlight (optional - for when user scrolls to section) */
 .quick-nav-list a.active {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 /* Section anchor indicators */
@@ -258,7 +258,7 @@ section[id] {
 
 .why-study {
     padding: 80px 20px;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 .reasons-grid {
@@ -268,10 +268,10 @@ section[id] {
 }
 
 .reason-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 25px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     text-align: center;
     transition: all 0.3s ease;
     position: relative;
@@ -295,25 +295,25 @@ section[id] {
 
 .reason-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .reason-card i {
     font-size: 40px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 20px;
 }
 
 .reason-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .reason-card p {
     font-size: 15px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -321,7 +321,7 @@ section[id] {
 
 .top-universities {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .universities-grid {
@@ -331,11 +331,11 @@ section[id] {
 }
 
 .uni-card {
-    background: white;
+    background: var(--bg-card);
     border-radius: 14px;
     padding: 30px;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
     display: flex;
     flex-direction: column;
@@ -343,13 +343,13 @@ section[id] {
 
 .uni-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .uni-icon {
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -361,21 +361,21 @@ section[id] {
 
 .uni-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .uni-location {
     font-size: 14px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 600;
     margin-bottom: 15px;
 }
 
 .uni-desc {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     flex-grow: 1;
     margin-bottom: 20px;
@@ -383,24 +383,24 @@ section[id] {
 
 .learn-more {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     transition: 0.3s;
-    border-bottom: 2px solid #8d2123;
+    border-bottom: 2px solid var(--accent);
     padding-bottom: 4px;
 }
 
 .learn-more:hover {
-    color: #6a181b;
-    border-color: #6a181b;
+    color: var(--accent-dark);
+    border-color: var(--accent-dark);
 }
 
 /* ===== POPULAR COURSES SECTION ===== */
 
 .popular-courses {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .courses-grid {
@@ -410,8 +410,8 @@ section[id] {
 }
 
 .course-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px 20px;
     border-radius: 12px;
     text-align: center;
@@ -419,27 +419,27 @@ section[id] {
 }
 
 .course-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-6px);
     box-shadow: 0 15px 35px rgba(141, 33, 35, 0.12);
 }
 
 .course-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .course-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 10px;
     font-weight: 700;
 }
 
 .course-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -447,7 +447,7 @@ section[id] {
 
 .pte-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .pte-content {
@@ -457,22 +457,22 @@ section[id] {
 }
 
 .pte-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .pte-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .pte-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -484,14 +484,14 @@ section[id] {
 
 .pte-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .pte-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -499,7 +499,7 @@ section[id] {
 
 .intakes-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .intakes-timeline {
@@ -513,21 +513,21 @@ section[id] {
 .intake-item {
     display: flex;
     gap: 20px;
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .intake-item:hover {
     transform: translateX(8px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .intake-month {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     min-width: 80px;
     height: 80px;
@@ -542,14 +542,14 @@ section[id] {
 
 .intake-details h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .intake-details p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -557,7 +557,7 @@ section[id] {
 
 .work-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .work-grid {
@@ -567,35 +567,35 @@ section[id] {
 }
 
 .work-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .work-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .work-card i {
     font-size: 38px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
 }
 
 .work-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .work-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -603,7 +603,7 @@ section[id] {
 
 .visa-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .visa-content {
@@ -615,29 +615,29 @@ section[id] {
 }
 
 .visa-box {
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
-    border: 1px solid #e8e8e8;
+    background: var(--bg-card);
+    border: 1px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .visa-box:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     box-shadow: 0 12px 30px rgba(141, 33, 35, 0.12);
 }
 
 .visa-box h3 {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
     font-weight: 700;
 }
 
 .visa-box p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -645,7 +645,7 @@ section[id] {
     list-style: none;
     padding: 0;
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.8;
 }
 
@@ -659,7 +659,7 @@ section[id] {
     content: "✓";
     position: absolute;
     left: 0;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: bold;
 }
 
@@ -667,7 +667,7 @@ section[id] {
 
 .cost-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cost-grid {
@@ -678,69 +678,69 @@ section[id] {
 }
 
 .cost-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .cost-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 35px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .cost-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .cost-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .cost-amount {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 700;
     margin: 12px 0;
 }
 
 .cost-card p {
     font-size: 13px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
 .cost-summary {
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
     text-align: center;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
 }
 
 .cost-summary p {
     font-size: 16px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin: 0;
 }
 
 .cost-summary strong {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 /* ===== SCHOLARSHIPS SECTION ===== */
 
 .scholarships-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .scholarships-grid {
@@ -750,8 +750,8 @@ section[id] {
 }
 
 .scholarship-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
     transition: all 0.3s ease;
@@ -759,14 +759,14 @@ section[id] {
 }
 
 .scholarship-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-8px);
     box-shadow: 0 16px 40px rgba(141, 33, 35, 0.12);
 }
 
 .scholarship-badge {
     display: inline-block;
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     padding: 6px 14px;
     border-radius: 20px;
@@ -779,14 +779,14 @@ section[id] {
 
 .scholarship-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .scholarship-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -794,7 +794,7 @@ section[id] {
 
 .cities-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cities-grid {
@@ -804,22 +804,22 @@ section[id] {
 }
 
 .city-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 28px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .city-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .city-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -831,23 +831,27 @@ section[id] {
 
 .city-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .city-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     margin-bottom: 8px;
+}
+
+.city-card p strong {
+    color: var(--text-primary);
 }
 
 /* ===== QUICK FACTS SECTION ===== */
 
 .facts-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .facts-grid {
@@ -857,7 +861,7 @@ section[id] {
 }
 
 .fact-card {
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     color: white;
     padding: 30px 20px;
     border-radius: 12px;
@@ -898,7 +902,7 @@ section[id] {
 
 .faq-section {
     padding: 100px 20px;
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
+    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
     position: relative;
 }
 
@@ -927,17 +931,17 @@ section[id] {
 .faq-item {
     border-radius: 12px;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--bg-faq-item);
     backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--border-card);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .faq-item:hover {
     transform: translateY(-4px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
-    border-color: #8d2123;
+    box-shadow: var(--shadow-lift);
+    border-color: var(--accent);
 }
 
 .faq-question {
@@ -947,7 +951,7 @@ section[id] {
     background: transparent;
     font-size: 16px;
     font-weight: 600;
-    color: #1a1a1a;
+    color: var(--text-primary);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -955,9 +959,10 @@ section[id] {
     transition: 0.3s;
 }
 
-.faq-question i {
+.faq-question i,
+.faq-question span {
     font-size: 16px;
-    color: #8d2123;
+    color: var(--accent);
     transition: 0.3s;
 }
 
@@ -970,13 +975,13 @@ section[id] {
 
 .faq-answer p {
     padding: 15px 0 20px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.7;
     font-size: 14px;
 }
 
 .faq-item.active .faq-question {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 .faq-item.active .faq-question i {
@@ -1046,23 +1051,23 @@ section[id] {
 .back-to-home {
     padding: 40px 20px;
     text-align: center;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .back-button {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     font-size: 16px;
     padding: 12px 24px;
-    border: 2px solid #8d2123;
+    border: 2px solid var(--accent);
     border-radius: 8px;
     transition: all 0.3s ease;
 }
 
 .back-button:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateX(-5px);
 }
@@ -1208,14 +1213,14 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+    background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #6a181b;
+    background: var(--accent-dark);
 }

--- a/styles/css/canada.css
+++ b/styles/css/canada.css
@@ -9,9 +9,9 @@
 
 body {
     font-family: 'Arial', sans-serif;
-    color: #1a1a1a;
+    color: var(--text-primary);
     line-height: 1.6;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 /* Section Container */
@@ -30,14 +30,14 @@ body {
 .section-header h2 {
     font-size: 38px;
     font-weight: 700;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 15px;
     letter-spacing: -0.5px;
 }
 
 .section-header p {
     font-size: 17px;
-    color: #555;
+    color: var(--text-muted);
     max-width: 700px;
     margin: 0 auto;
     line-height: 1.65;
@@ -120,8 +120,8 @@ body {
 /* ===== QUICK NAVIGATION MENU ===== */
 
 .quick-nav {
-    background: white;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    background: var(--bg-card);
+    box-shadow: var(--shadow-soft);
     padding: 30px 20px;
     position: sticky;
     top: 0;
@@ -136,7 +136,7 @@ body {
 .quick-nav-title {
     font-size: 18px;
     font-weight: 700;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
     display: flex;
     align-items: center;
@@ -157,8 +157,8 @@ body {
     align-items: center;
     gap: 8px;
     padding: 10px 16px;
-    background: #f7f7f7;
-    color: #1a1a1a;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
     text-decoration: none;
     border-radius: 8px;
     font-size: 14px;
@@ -168,10 +168,10 @@ body {
 }
 
 .quick-nav-list a:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateY(-3px);
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 .quick-nav-list i {
@@ -180,9 +180,9 @@ body {
 }
 
 .quick-nav-list a.active {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 section[id] {
@@ -193,7 +193,7 @@ section[id] {
 
 .why-study {
     padding: 80px 20px;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 .reasons-grid {
@@ -203,10 +203,10 @@ section[id] {
 }
 
 .reason-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 25px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     text-align: center;
     transition: all 0.3s ease;
     position: relative;
@@ -230,25 +230,25 @@ section[id] {
 
 .reason-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .reason-card i {
     font-size: 40px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 20px;
 }
 
 .reason-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .reason-card p {
     font-size: 15px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -256,7 +256,7 @@ section[id] {
 
 .top-universities {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .universities-grid {
@@ -266,11 +266,11 @@ section[id] {
 }
 
 .uni-card {
-    background: white;
+    background: var(--bg-card);
     border-radius: 14px;
     padding: 30px;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
     display: flex;
     flex-direction: column;
@@ -278,13 +278,13 @@ section[id] {
 
 .uni-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .uni-icon {
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -296,21 +296,21 @@ section[id] {
 
 .uni-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .uni-location {
     font-size: 14px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 600;
     margin-bottom: 15px;
 }
 
 .uni-desc {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     flex-grow: 1;
     margin-bottom: 20px;
@@ -318,24 +318,24 @@ section[id] {
 
 .learn-more {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     transition: 0.3s;
-    border-bottom: 2px solid #8d2123;
+    border-bottom: 2px solid var(--accent);
     padding-bottom: 4px;
 }
 
 .learn-more:hover {
-    color: #6a181b;
-    border-color: #6a181b;
+    color: var(--accent-dark);
+    border-color: var(--accent-dark);
 }
 
 /* ===== POPULAR COURSES SECTION ===== */
 
 .popular-courses {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .courses-grid {
@@ -345,8 +345,8 @@ section[id] {
 }
 
 .course-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px 20px;
     border-radius: 12px;
     text-align: center;
@@ -354,27 +354,27 @@ section[id] {
 }
 
 .course-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-6px);
     box-shadow: 0 15px 35px rgba(141, 33, 35, 0.12);
 }
 
 .course-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .course-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 10px;
     font-weight: 700;
 }
 
 .course-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -382,7 +382,7 @@ section[id] {
 
 .pte-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .pte-content {
@@ -392,22 +392,22 @@ section[id] {
 }
 
 .pte-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .pte-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .pte-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -419,14 +419,14 @@ section[id] {
 
 .pte-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .pte-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -434,7 +434,7 @@ section[id] {
 
 .intakes-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .intakes-timeline {
@@ -448,21 +448,21 @@ section[id] {
 .intake-item {
     display: flex;
     gap: 20px;
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .intake-item:hover {
     transform: translateX(8px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .intake-month {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     min-width: 80px;
     height: 80px;
@@ -477,14 +477,14 @@ section[id] {
 
 .intake-details h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .intake-details p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -492,7 +492,7 @@ section[id] {
 
 .work-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .work-grid {
@@ -502,35 +502,35 @@ section[id] {
 }
 
 .work-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .work-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .work-card i {
     font-size: 38px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
 }
 
 .work-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .work-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -538,7 +538,7 @@ section[id] {
 
 .visa-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .visa-content {
@@ -550,29 +550,29 @@ section[id] {
 }
 
 .visa-box {
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
-    border: 1px solid #e8e8e8;
+    background: var(--bg-card);
+    border: 1px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .visa-box:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     box-shadow: 0 12px 30px rgba(141, 33, 35, 0.12);
 }
 
 .visa-box h3 {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
     font-weight: 700;
 }
 
 .visa-box p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -580,7 +580,7 @@ section[id] {
     list-style: none;
     padding: 0;
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.8;
 }
 
@@ -594,7 +594,7 @@ section[id] {
     content: "✓";
     position: absolute;
     left: 0;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: bold;
 }
 
@@ -602,7 +602,7 @@ section[id] {
 
 .cost-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cost-grid {
@@ -613,69 +613,69 @@ section[id] {
 }
 
 .cost-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .cost-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 35px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .cost-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .cost-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .cost-amount {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 700;
     margin: 12px 0;
 }
 
 .cost-card p {
     font-size: 13px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
 .cost-summary {
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
     text-align: center;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
 }
 
 .cost-summary p {
     font-size: 16px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin: 0;
 }
 
 .cost-summary strong {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 /* ===== SCHOLARSHIPS SECTION ===== */
 
 .scholarships-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .scholarships-grid {
@@ -685,8 +685,8 @@ section[id] {
 }
 
 .scholarship-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
     transition: all 0.3s ease;
@@ -694,14 +694,14 @@ section[id] {
 }
 
 .scholarship-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-8px);
     box-shadow: 0 16px 40px rgba(141, 33, 35, 0.12);
 }
 
 .scholarship-badge {
     display: inline-block;
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     padding: 6px 14px;
     border-radius: 20px;
@@ -714,14 +714,14 @@ section[id] {
 
 .scholarship-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .scholarship-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -729,7 +729,7 @@ section[id] {
 
 .cities-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cities-grid {
@@ -739,22 +739,22 @@ section[id] {
 }
 
 .city-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 28px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .city-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .city-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -766,23 +766,27 @@ section[id] {
 
 .city-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .city-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     margin-bottom: 8px;
+}
+
+.city-card p strong {
+    color: var(--text-primary);
 }
 
 /* ===== QUICK FACTS SECTION ===== */
 
 .facts-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .facts-grid {
@@ -792,7 +796,7 @@ section[id] {
 }
 
 .fact-card {
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     color: white;
     padding: 30px 20px;
     border-radius: 12px;
@@ -833,7 +837,7 @@ section[id] {
 
 .faq-section {
     padding: 100px 20px;
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
+    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
     position: relative;
 }
 
@@ -862,17 +866,17 @@ section[id] {
 .faq-item {
     border-radius: 12px;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--bg-faq-item);
     backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--border-card);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .faq-item:hover {
     transform: translateY(-4px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
-    border-color: #8d2123;
+    box-shadow: var(--shadow-lift);
+    border-color: var(--accent);
 }
 
 .faq-question {
@@ -882,7 +886,7 @@ section[id] {
     background: transparent;
     font-size: 16px;
     font-weight: 600;
-    color: #1a1a1a;
+    color: var(--text-primary);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -890,9 +894,10 @@ section[id] {
     transition: 0.3s;
 }
 
-.faq-question i {
+.faq-question i,
+.faq-question span {
     font-size: 16px;
-    color: #8d2123;
+    color: var(--accent);
     transition: 0.3s;
 }
 
@@ -905,13 +910,13 @@ section[id] {
 
 .faq-answer p {
     padding: 15px 0 20px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.7;
     font-size: 14px;
 }
 
 .faq-item.active .faq-question {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 .faq-item.active .faq-question i {
@@ -981,23 +986,23 @@ section[id] {
 .back-to-home {
     padding: 40px 20px;
     text-align: center;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .back-button {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     font-size: 16px;
     padding: 12px 24px;
-    border: 2px solid #8d2123;
+    border: 2px solid var(--accent);
     border-radius: 8px;
     transition: all 0.3s ease;
 }
 
 .back-button:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateX(-5px);
 }
@@ -1166,14 +1171,14 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+    background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #6a181b;
+    background: var(--accent-dark);
 }

--- a/styles/css/style.css
+++ b/styles/css/style.css
@@ -9,7 +9,8 @@ body {
 
 /* Header */
 #header {
-    position: absolute; /* overlay on hero */
+    position: absolute;
+    /* overlay on hero */
     top: 0;
     left: 0;
     width: 100%;
@@ -22,7 +23,8 @@ body {
 
     z-index: 999;
 
-    background: transparent; /* IMPORTANT */
+    background: transparent;
+    /* IMPORTANT */
 }
 
 #header img {
@@ -31,19 +33,19 @@ body {
 }
 
 #navbar-container {
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-    width:100%;
-    position:relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
 }
 
 #navbar {
-    display:flex;
-    flex-direction:row;
-    align-items:center;
-    justify-content:center;
-    gap:20px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
 }
 
 #navbar li {
@@ -71,25 +73,28 @@ body {
     display: none;
 }
 
-#address, #address1{
-    background:#8d2123;
-    color:white;
-    border:none;
-    border-radius:8px;
-    padding:12px 26px;
-    font-size:15px;
-    font-weight:600;
-    cursor:pointer;
-    transition:all 0.3s ease;
+#address,
+#address1 {
+    background: #8d2123;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 26px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
 }
 
-#address:hover, #address1:hover{
-    background:#6a181b;
-    transform:translateY(-2px);
-    box-shadow:0 8px 20px rgba(0,0,0,0.3);
+#address:hover,
+#address1:hover {
+    background: #6a181b;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
 }
 
-#address:hover, #address1:hover {
+#address:hover,
+#address1:hover {
     background-color: #6a181b;
 }
 
@@ -104,217 +109,219 @@ body {
 }
 
 /* Hero Section */
-.hero-image{
-    background-image:url('../../assets/images/hero.jpg');
-    background-size:cover;
-    background-position:center;
+.hero-image {
+    background-image: url('../../assets/images/hero.jpg');
+    background-size: cover;
+    background-position: center;
     width: 100%;
     position: relative;
     overflow: hidden;
-    min-height:calc(100vh - 80px); /* adjust based on navbar height */
+    min-height: calc(100vh - 80px);
+    /* adjust based on navbar height */
 
-    display:flex;
+    display: flex;
     flex: 1;
-    padding:80px 40px 40px 40px;
+    padding: 80px 40px 40px 40px;
 }
 
-.hero-wrapper{
-    display:flex;
-    align-items:center;
-    justify-content:flex-start;
-    max-width:1200px;
-    width:100%;
-        padding:80px 40px 40px 40px;
+.hero-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    max-width: 1200px;
+    width: 100%;
+    padding: 80px 40px 40px 40px;
 
-    padding:80px 40px 40px 40px;
+    padding: 80px 40px 40px 40px;
 }
 
-.hero-text{
-    max-width:460px;
-    background:rgba(255,255,255,0.85);
-    backdrop-filter:blur(14px);
-    padding:25px 38px 35px 38px;
-    border-radius:8px;
-    box-shadow:0 20px 60px rgba(0,0,0,0.22);
-    border:1px solid rgba(255,255,255,0.35);
+.hero-text {
+    max-width: 460px;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(14px);
+    padding: 25px 38px 35px 38px;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22);
+    border: 1px solid rgba(255, 255, 255, 0.35);
 }
 
-.hero-text h2{
-    font-size:38px;
-    font-weight:700;
-    line-height:1.25;
-    margin-top:0;
-    margin-bottom:12px;
-    color:#1a1a1a;
+.hero-text h2 {
+    font-size: 38px;
+    font-weight: 700;
+    line-height: 1.25;
+    margin-top: 0;
+    margin-bottom: 12px;
+    color: #1a1a1a;
 }
 
-.hero-text h3{
-    font-size:24px;
-    font-weight:500;
-    margin-bottom:22px;
-    color:#444;
+.hero-text h3 {
+    font-size: 24px;
+    font-weight: 500;
+    margin-bottom: 22px;
+    color: #444;
 }
 
-.hero-text p{
-    margin:8px 0;
-    font-size:15px;
-    line-height:1.6;
-    color:#555;
+.hero-text p {
+    margin: 8px 0;
+    font-size: 15px;
+    line-height: 1.6;
+    color: #555;
 }
 
-.hero-text button{
-    margin-top:22px;
+.hero-text button {
+    margin-top: 22px;
 }
 
-.hero-points{
-    list-style:none;
-    padding:0;
-    margin:18px 0 22px 0;
+.hero-points {
+    list-style: none;
+    padding: 0;
+    margin: 18px 0 22px 0;
 }
 
-.hero-points li{
-    display:flex;
-    align-items:flex-start;
-    gap:10px;
-    font-size:15px;
-    color:#555;
-    margin-bottom:8px;
-    line-height:1.5;
+.hero-points li {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 15px;
+    color: #555;
+    margin-bottom: 8px;
+    line-height: 1.5;
 }
 
-.hero-points i{
-    color:#8d2123;
-    margin-top:3px;
-    font-size:14px;
+.hero-points i {
+    color: #8d2123;
+    margin-top: 3px;
+    font-size: 14px;
 }
 
-.hero-actions{
-    margin-top:10px;
+.hero-actions {
+    margin-top: 10px;
 }
 
-section.reveal{
-    padding:80px 20px;
-    text-align:center;
+section.reveal {
+    padding: 80px 20px;
+    text-align: center;
 }
 
-section.reveal:nth-of-type(even){
-    background:#ffffff;
+section.reveal:nth-of-type(even) {
+    background: #ffffff;
 }
 
-section.reveal:nth-of-type(odd){
-    background:#f7f7f7;
+section.reveal:nth-of-type(odd) {
+    background: #f7f7f7;
 }
 
-.features-heading h2{
-    font-size:32px;
-    margin-bottom:10px;
+.features-heading h2 {
+    font-size: 32px;
+    margin-bottom: 10px;
 }
 
-.features-heading p{
-    color:#555;
-    margin-bottom:40px;
+.features-heading p {
+    color: #555;
+    margin-bottom: 40px;
 }
 
-#page2{
-    background:#ffffff;
-    padding:80px 20px;
+#page2 {
+    background: #ffffff;
+    padding: 80px 20px;
 }
 
-#alpha{
-    text-align:center;
-    margin-bottom:40px;
+#alpha {
+    text-align: center;
+    margin-bottom: 40px;
 }
 
-#alpha h2{
-    font-size:32px;
-    color:#1a1a1a;
+#alpha h2 {
+    font-size: 32px;
+    color: #1a1a1a;
 }
 
-#alpha p{
-    color:#555;
+#alpha p {
+    color: #555;
 }
 
 
 /* Cards Section */
-#container{
-    max-width:1200px;
-    margin:auto;
-    display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
-    gap:30px;
+#container {
+    max-width: 1200px;
+    margin: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 30px;
 }
 
-#container .cards::after{
-    content:"";
-    position:absolute;
-    inset:0;
-    background:linear-gradient(120deg, transparent, rgba(255,255,255,0.3), transparent);
-    opacity:0;
-    transition:0.4s;
+#container .cards::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.3), transparent);
+    opacity: 0;
+    transition: 0.4s;
     pointer-events: none;
 }
 
-#container .cards:hover::after{
-    opacity:1;
+#container .cards:hover::after {
+    opacity: 1;
 }
 
-#container .cards{
-    width:100%;
-    background:#ffffff;
+#container .cards {
+    width: 100%;
+    background: #ffffff;
 
-    border-radius:12px;
-    overflow:visible;
-    position:relative;
+    border-radius: 12px;
+    overflow: visible;
+    position: relative;
 
-    box-shadow:0 10px 25px rgba(0,0,0,0.08);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
 
-    transition:all 0.4s ease;
+    transition: all 0.4s ease;
 
-    text-align:center;
-    padding-bottom:25px;
+    text-align: center;
+    padding-bottom: 25px;
 }
 
 
 
-#address, #address1{
-    letter-spacing:0.5px;
+#address,
+#address1 {
+    letter-spacing: 0.5px;
 }
 
-#container .cards:hover{
-    transform:translateY(-10px);
-    box-shadow:0 20px 40px rgba(0,0,0,0.15);
+#container .cards:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
 }
 
-#container .cards img{
-    width:100%;
-    height:220px;
+#container .cards img {
+    width: 100%;
+    height: 220px;
 
-    object-fit:cover;
+    object-fit: cover;
 
-    border-top-left-radius:12px;
-    border-top-right-radius:12px;
+    border-top-left-radius: 12px;
+    border-top-right-radius: 12px;
 
-    transition:transform 0.4s ease;
+    transition: transform 0.4s ease;
 }
 
-#container .cards:hover img{
-    transform:scale(1.08);
+#container .cards:hover img {
+    transform: scale(1.08);
 }
 
-#container .cards h3{
-    margin-top:20px;
-    font-size:20px;
-    color:#1a1a1a;
+#container .cards h3 {
+    margin-top: 20px;
+    font-size: 20px;
+    color: #1a1a1a;
 }
 
-#container .cards p{
-    padding:0 20px;
-    color:#555;
-    line-height:1.5;
+#container .cards p {
+    padding: 0 20px;
+    color: #555;
+    line-height: 1.5;
 }
 
-#container .cards button{
-    margin-top:15px;
+#container .cards button {
+    margin-top: 15px;
 }
 
 /* Book Now Button */
@@ -344,52 +351,66 @@ section.reveal:nth-of-type(odd){
 .book-now-btn:active {
     transform: translateY(0);
 }
+
 /* Reviews Section */
 #contact {
-    background:#f7f7f7;
-    padding:80px 20px;
+    background: #f7f7f7;
+    padding: 80px 20px;
     text-align: center;
 }
 
-#reviews{
-    max-width:1100px;
-    margin:40px auto;
-
-    display:flex;
-    gap:25px;
-
-    overflow-x:auto;
-    scroll-behavior:smooth;
-
-    padding-bottom:10px;
+.reviews-scroll-wrapper {
+    overflow: hidden;
+    width: 100%;
+    max-width: 1100px;
+    margin: 40px auto;
+    position: relative;
 }
 
-#reviews::-webkit-scrollbar{
-    height:6px;
+#reviews {
+    display: flex;
+    width: max-content;
+    animation: scroll-reviews 30s linear infinite;
 }
 
-#reviews::-webkit-scrollbar-thumb{
-    background:#8d2123;
-    border-radius:10px;
+#reviews:hover {
+    animation-play-state: paused;
 }
 
-.review{
-    min-width:240px;
-    max-width:260px;
-    background:#fff;
-
-    padding:25px;
-
-    border-radius:12px;
-
-    box-shadow:0 8px 20px rgba(0,0,0,0.08);
-
-    transition:all 0.3s ease;
+#reviews::-webkit-scrollbar {
+    display: none;
 }
 
-.review:hover{
-    transform:translateY(-6px);
-    box-shadow:0 18px 40px rgba(0,0,0,0.15);
+#reviews {
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    scrollbar-width: none;
+    /* Firefox */
+}
+
+.reviews-slide {
+    display: flex;
+    gap: 25px;
+    padding-right: 25px;
+}
+
+.review {
+    min-width: 240px;
+    max-width: 260px;
+    background: #fff;
+
+    padding: 25px;
+
+    border-radius: 12px;
+
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+
+    transition: all 0.3s ease;
+}
+
+.review:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
 }
 
 .review h3 {
@@ -401,6 +422,16 @@ section.reveal:nth-of-type(odd){
 .review p {
     font-size: 1em;
     color: #555;
+}
+
+@keyframes scroll-reviews {
+    0% {
+        transform: translateX(0);
+    }
+
+    100% {
+        transform: translateX(-50%);
+    }
 }
 
 /* Footer */
@@ -447,17 +478,17 @@ footer a:hover {
 /* Responsive Adjustments */
 @media (max-width: 768px) {
     #navbar {
-        display:none;
-        flex-direction:column;
-        gap:10px;
-        width:100%;
-        text-align:center;
-        background:#E3E6F3;
-        padding:15px 0;
+        display: none;
+        flex-direction: column;
+        gap: 10px;
+        width: 100%;
+        text-align: center;
+        background: #E3E6F3;
+        padding: 15px 0;
     }
 
-    #navbar.active{
-        display:flex;
+    #navbar.active {
+        display: flex;
     }
 
     #mobile {
@@ -470,7 +501,8 @@ footer a:hover {
         align-items: center;
     }
 
-    #address, #address1 {
+    #address,
+    #address1 {
         width: 100%;
         margin: 10px 0;
     }
@@ -493,7 +525,9 @@ footer a:hover {
         padding: 20px;
     }
 
-    #box1 h2, #box1 h3, #box1 h5 {
+    #box1 h2,
+    #box1 h3,
+    #box1 h5 {
         font-size: 1em;
     }
 
@@ -517,436 +551,455 @@ footer a:hover {
         padding: 10px;
     }
 
-    #address, #address1 {
+    #address,
+    #address1 {
         padding: 8px 15px;
     }
 }
 
-@media (max-width:768px){
+@media (max-width:768px) {
 
-    #point{
-        padding:80px 20px 30px 20px;
-        min-height:auto;
+    #point {
+        padding: 80px 20px 30px 20px;
+        min-height: auto;
     }
 
-    .hero-wrapper{
-        flex-direction:column;
-        justify-content:center;
-        align-items:center;
-        text-align:center;
+    .hero-wrapper {
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        text-align: center;
     }
 
-    .hero-text{
-        max-width:100%;
-        padding:20px;
+    .hero-text {
+        max-width: 100%;
+        padding: 20px;
     }
 
-    .hero-text h2{
-        font-size:26px;
+    .hero-text h2 {
+        font-size: 26px;
     }
 
-    .hero-text h3{
-        font-size:18px;
+    .hero-text h3 {
+        font-size: 18px;
     }
 
 }
 
 /* LOGIN REQUIRED POPUP */
 
-.auth-popup-overlay{
+.auth-popup-overlay {
 
-    position:fixed;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
 
-    background:rgba(0,0,0,0.45);
+    background: rgba(0, 0, 0, 0.45);
 
-    display:flex;
-    align-items:center;
-    justify-content:center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    z-index:2000;
+    z-index: 2000;
 }
 
-.auth-popup{
+.auth-popup {
 
-    background:white;
-    padding:35px 40px;
+    background: white;
+    padding: 35px 40px;
 
-    border-radius:16px;
+    border-radius: 16px;
 
-    width:320px;
+    width: 320px;
 
-    text-align:center;
+    text-align: center;
 
-    box-shadow:0 15px 40px rgba(0,0,0,0.2);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.2);
 }
 
-.auth-popup h3{
-    margin-bottom:10px;
+.auth-popup h3 {
+    margin-bottom: 10px;
 }
 
-.auth-popup p{
-    font-size:14px;
-    color:#666;
-    margin-bottom:20px;
+.auth-popup p {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 20px;
 }
 
-.auth-popup-actions{
-    display:flex;
-    gap:10px;
-    justify-content:center;
+.auth-popup-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
 }
 
-.popup-login-btn{
+.popup-login-btn {
 
-    background:#2f855a;
-    color:white;
+    background: #2f855a;
+    color: white;
 
-    padding:10px 18px;
+    padding: 10px 18px;
 
-    border-radius:8px;
+    border-radius: 8px;
 
-    text-decoration:none;
+    text-decoration: none;
 }
 
-.popup-close-btn{
+.popup-close-btn {
 
-    padding:10px 18px;
+    padding: 10px 18px;
 
-    border:none;
+    border: none;
 
-    background:#ddd;
+    background: #ddd;
 
-    border-radius:8px;
+    border-radius: 8px;
 
-    cursor:pointer;
+    cursor: pointer;
 }
 
 /* SCROLL TO TOP BUTTON */
 
-#scrollTopBtn{
-  position:fixed;
+#scrollTopBtn {
+    position: fixed;
 
-  bottom:30px;
-  right:30px;
+    bottom: 30px;
+    right: 30px;
 
-  width:44px;
-  height:44px;
+    width: 44px;
+    height: 44px;
 
-  border:none;
-  border-radius:50%;
+    border: none;
+    border-radius: 50%;
 
-  background:#8d2123;
-  color:white;
+    background: #8d2123;
+    color: white;
 
-  font-size:18px;
+    font-size: 18px;
 
-  display:none; /* hidden initially */
+    display: none;
+    /* hidden initially */
 
-  align-items:center;
-  justify-content:center;
+    align-items: center;
+    justify-content: center;
 
-  cursor:pointer;
+    cursor: pointer;
 
-  box-shadow:0 6px 18px rgba(0,0,0,0.25);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
 
-  transition:all 0.25s ease;
+    transition: all 0.25s ease;
 
-  z-index:9999;
+    z-index: 9999;
 }
 
-#scrollTopBtn.show{
-  display:flex;
+#scrollTopBtn.show {
+    display: flex;
 }
 
-#scrollTopBtn:hover{
-  background:#6f181a;
-  transform:translateY(-3px);
+#scrollTopBtn:hover {
+    background: #6f181a;
+    transform: translateY(-3px);
 }
 
 /* ===== MODERN SECTION LAYOUT ===== */
 
-.features-heading h2{
-    font-size:38px;
-    font-weight:700;
-    letter-spacing:-0.5px;
+.features-heading h2 {
+    font-size: 38px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
     margin-bottom: 10px;
-    color:#1a1a1a;
+    color: #1a1a1a;
 }
 
-.features-heading p{
-    font-size:17px;
-    line-height:1.6;
-    max-width:700px;
-    margin:0 auto 50px auto;
-    color:#555;
+.features-heading p {
+    font-size: 17px;
+    line-height: 1.6;
+    max-width: 700px;
+    margin: 0 auto 50px auto;
+    color: #555;
 }
 
 /* grid layout instead of flex */
 
-.features-container{
-    max-width:1200px;
-    margin:auto;
-    display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-    gap:30px;
+.features-container {
+    max-width: 1200px;
+    margin: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 30px;
 }
 
 /* modern cards */
 
-.feature-box{
-    background:white;
-    padding:35px 25px;
+.feature-box {
+    background: white;
+    padding: 35px 25px;
 
-    border-radius:14px;
-    text-align:center;
+    border-radius: 14px;
+    text-align: center;
 
-    box-shadow:0 8px 25px rgba(0,0,0,0.08);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
 
-    position:relative;
-    overflow:hidden;
+    position: relative;
+    overflow: hidden;
 
-    opacity:0;
-    transform:translateY(40px);
+    opacity: 0;
+    transform: translateY(40px);
 
-    transition:all 0.6s ease;
+    transition: all 0.6s ease;
 }
 
-.feature-box::before{
-    content:"";
-    position:absolute;
-    top:0;
-    left:-100%;
-    width:100%;
-    height:100%;
-    background:linear-gradient(120deg, transparent, rgba(255,255,255,0.6), transparent);
-    transition:0.6s;
+.feature-box::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+    transition: 0.6s;
 }
 
-.feature-box:hover::before{
-    left:100%;
+.feature-box:hover::before {
+    left: 100%;
 }
 
-.feature-box:hover{
-    transform:translateY(-8px);
-    box-shadow:0 18px 45px rgba(0,0,0,0.15);
+.feature-box:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
 }
 
-.feature-box i{
-    font-size:36px;
-    color:#8d2123;
-    margin-bottom:18px;
+.feature-box i {
+    font-size: 36px;
+    color: #8d2123;
+    margin-bottom: 18px;
 }
 
-.feature-box h3{
-    margin-bottom:12px;
+.feature-box h3 {
+    margin-bottom: 12px;
 }
 
-.feature-box p{
-    font-size:14px;
-    color:#555;
-    line-height:1.5;
+.feature-box p {
+    font-size: 14px;
+    color: #555;
+    line-height: 1.5;
 }
 
 /* ===== SCROLL ANIMATION ===== */
 
-.reveal{
-    opacity:0;
-    transform:translateY(40px);
-    transition:all 0.8s ease;
+.reveal {
+    opacity: 0;
+    transform: translateY(40px);
+    transition: all 0.8s ease;
 }
 
-.reveal.active{
-    opacity:1;
-    transform:translateY(0);
+.reveal.active {
+    opacity: 1;
+    transform: translateY(0);
 }
 
-.reveal.active .feature-box{
-    opacity:1;
-    transform:translateY(0);
+.reveal.active .feature-box {
+    opacity: 1;
+    transform: translateY(0);
 }
 
-.reveal.active .feature-box:nth-child(1){ transition-delay:0.1s; }
-.reveal.active .feature-box:nth-child(2){ transition-delay:0.2s; }
-.reveal.active .feature-box:nth-child(3){ transition-delay:0.3s; }
-.reveal.active .feature-box:nth-child(4){ transition-delay:0.4s; }
+.reveal.active .feature-box:nth-child(1) {
+    transition-delay: 0.1s;
+}
+
+.reveal.active .feature-box:nth-child(2) {
+    transition-delay: 0.2s;
+}
+
+.reveal.active .feature-box:nth-child(3) {
+    transition-delay: 0.3s;
+}
+
+.reveal.active .feature-box:nth-child(4) {
+    transition-delay: 0.4s;
+}
 
 
 /* smooth page scrolling */
 
-html{
-    scroll-behavior:smooth;
+html {
+    scroll-behavior: smooth;
 }
 
 /* SCROLLBAR (modern thin) */
 
-::-webkit-scrollbar{
-    width:6px;   /* vertical */
-    height:6px;  /* horizontal */
+::-webkit-scrollbar {
+    width: 6px;
+    /* vertical */
+    height: 6px;
+    /* horizontal */
 }
 
-::-webkit-scrollbar-track{
-    background:transparent;
+::-webkit-scrollbar-track {
+    background: transparent;
 }
 
-::-webkit-scrollbar-thumb{
-    background:#8d2123;
-    border-radius:10px;
+::-webkit-scrollbar-thumb {
+    background: #8d2123;
+    border-radius: 10px;
 }
 
-::-webkit-scrollbar-thumb:hover{
-    background:#6a181b;
+::-webkit-scrollbar-thumb:hover {
+    background: #6a181b;
 }
 
-#address, #address1{
-    position:relative;
-    overflow:hidden;
+#address,
+#address1 {
+    position: relative;
+    overflow: hidden;
 }
 
-#address::after, #address1::after{
-    content:"";
-    position:absolute;
-    top:0;
-    left:-100%;
-    width:100%;
-    height:100%;
-    background:rgba(255,255,255,0.2);
-    transition:0.4s;
+#address::after,
+#address1::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.2);
+    transition: 0.4s;
 }
 
-#address:hover::after, #address1:hover::after{
-    left:100%;
+#address:hover::after,
+#address1:hover::after {
+    left: 100%;
 }
 
-.hero-text{
-    animation:fadeUp 1s ease;
+.hero-text {
+    animation: fadeUp 1s ease;
 }
 
-@keyframes fadeUp{
-    from{
-        opacity:0;
-        transform:translateY(30px);
+@keyframes fadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
     }
-    to{
-        opacity:1;
-        transform:translateY(0);
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }
 
 /* SCROLL OFFSET FIX (for sticky navbar) */
 
-section{
+section {
     scroll-margin-top: 90px;
 }
 
 /* ===== ULTRA PREMIUM FAQ ===== */
 
-.faq-section{
-    padding:120px 20px;
-    background:linear-gradient(135deg,#f8f9fb,#ffffff);
-    position:relative;
+.faq-section {
+    padding: 120px 20px;
+    background: linear-gradient(135deg, #f8f9fb, #ffffff);
+    position: relative;
 }
 
 /* soft glow */
-.faq-section::before{
-    content:"";
-    position:absolute;
-    top:-100px;
-    left:-100px;
-    width:300px;
-    height:300px;
-    background:rgba(141,33,35,0.08);
-    border-radius:50%;
-    filter:blur(90px);
+.faq-section::before {
+    content: "";
+    position: absolute;
+    top: -100px;
+    left: -100px;
+    width: 300px;
+    height: 300px;
+    background: rgba(141, 33, 35, 0.08);
+    border-radius: 50%;
+    filter: blur(90px);
 }
 
 /* list */
-.faq-list{
-    max-width:850px;
-    margin:auto;
-    display:flex;
-    flex-direction:column;
-    gap:20px;
+.faq-list {
+    max-width: 850px;
+    margin: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }
 
 /* item */
-.faq-item{
-    border-radius:16px;
-    overflow:hidden;
-    background:rgba(255,255,255,0.7);
-    backdrop-filter:blur(12px);
+.faq-item {
+    border-radius: 16px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(12px);
 
-    border:1px solid rgba(255,255,255,0.4);
+    border: 1px solid rgba(255, 255, 255, 0.4);
 
-    box-shadow:0 10px 30px rgba(0,0,0,0.08);
-    transition:all 0.3s ease;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    transition: all 0.3s ease;
 }
 
-.faq-item:hover{
-    transform:translateY(-4px) scale(1.01);
-    box-shadow:0 20px 50px rgba(0,0,0,0.15);
+.faq-item:hover {
+    transform: translateY(-4px) scale(1.01);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
 }
 
 /* question */
-.faq-question{
-    width:100%;
-    padding:22px 24px;
-    border:none;
-    background:transparent;
+.faq-question {
+    width: 100%;
+    padding: 22px 24px;
+    border: none;
+    background: transparent;
 
-    font-size:16px;
-    font-weight:600;
+    font-size: 16px;
+    font-weight: 600;
 
-    display:flex;
-    justify-content:space-between;
-    align-items:center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
-    cursor:pointer;
+    cursor: pointer;
 }
 
 /* icon */
-.faq-question span{
-    width:32px;
-    height:32px;
+.faq-question span {
+    width: 32px;
+    height: 32px;
 
-    display:flex;
-    align-items:center;
-    justify-content:center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    background:#8d2123;
-    color:white;
+    background: #8d2123;
+    color: white;
 
-    border-radius:50%;
-    font-size:18px;
+    border-radius: 50%;
+    font-size: 18px;
 
-    transition:0.3s;
+    transition: 0.3s;
 }
 
 /* answer */
-.faq-answer{
-    max-height:0;
-    overflow:hidden;
+.faq-answer {
+    max-height: 0;
+    overflow: hidden;
 
-    transition:max-height 0.4s ease;
+    transition: max-height 0.4s ease;
 
-    padding:0 24px;
+    padding: 0 24px;
 }
 
-.faq-answer p{
-    padding:15px 0 20px;
-    color:#555;
-    line-height:1.6;
+.faq-answer p {
+    padding: 15px 0 20px;
+    color: #555;
+    line-height: 1.6;
 }
 
 /* active */
-.faq-item.active .faq-answer{
-    max-height:300px;
+.faq-item.active .faq-answer {
+    max-height: 300px;
 }
 
-.faq-item.active .faq-question span{
-    transform:rotate(45deg);
-    background:#6f1a1c;
+.faq-item.active .faq-question span {
+    transform: rotate(45deg);
+    background: #6f1a1c;
 }

--- a/styles/css/uk.css
+++ b/styles/css/uk.css
@@ -10,9 +10,9 @@
 
 body {
     font-family: 'Arial', sans-serif;
-    color: #1a1a1a;
+    color: var(--text-primary);
     line-height: 1.6;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 /* Section Container */
@@ -31,14 +31,14 @@ body {
 .section-header h2 {
     font-size: 38px;
     font-weight: 700;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 15px;
     letter-spacing: -0.5px;
 }
 
 .section-header p {
     font-size: 17px;
-    color: #555;
+    color: var(--text-muted);
     max-width: 700px;
     margin: 0 auto;
     line-height: 1.65;
@@ -56,6 +56,7 @@ body {
     background-attachment: fixed;
     background-repeat: no-repeat;
 }
+
 .unitedkingdom-overlay {
     position: absolute;
     inset: 0;
@@ -111,6 +112,7 @@ body {
         opacity: 0;
         transform: translateY(30px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -120,8 +122,8 @@ body {
 /* ===== QUICK NAVIGATION MENU ===== */
 
 .quick-nav {
-    background: white;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    background: var(--bg-card);
+    box-shadow: var(--shadow-soft);
     padding: 30px 20px;
     position: sticky;
     top: 0;
@@ -136,14 +138,12 @@ body {
 .quick-nav-title {
     font-size: 18px;
     font-weight: 700;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
     display: flex;
     align-items: center;
     gap: 10px;
 }
-
-
 
 .quick-nav-list {
     list-style: none;
@@ -159,8 +159,8 @@ body {
     align-items: center;
     gap: 8px;
     padding: 10px 16px;
-    background: #f7f7f7;
-    color: #1a1a1a;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
     text-decoration: none;
     border-radius: 8px;
     font-size: 14px;
@@ -170,10 +170,10 @@ body {
 }
 
 .quick-nav-list a:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateY(-3px);
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 .quick-nav-list i {
@@ -182,9 +182,9 @@ body {
 }
 
 .quick-nav-list a.active {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
-    border-color: #8d2123;
+    border-color: var(--accent);
 }
 
 section[id] {
@@ -195,7 +195,7 @@ section[id] {
 
 .why-study {
     padding: 80px 20px;
-    background: #ffffff;
+    background: var(--bg-primary);
 }
 
 .reasons-grid {
@@ -205,10 +205,10 @@ section[id] {
 }
 
 .reason-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 25px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     text-align: center;
     transition: all 0.3s ease;
     position: relative;
@@ -232,25 +232,25 @@ section[id] {
 
 .reason-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .reason-card i {
     font-size: 40px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 20px;
 }
 
 .reason-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .reason-card p {
     font-size: 15px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -258,7 +258,7 @@ section[id] {
 
 .top-universities {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .universities-grid {
@@ -268,11 +268,11 @@ section[id] {
 }
 
 .uni-card {
-    background: white;
+    background: var(--bg-card);
     border-radius: 14px;
     padding: 30px;
     text-align: center;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
     display: flex;
     flex-direction: column;
@@ -280,13 +280,13 @@ section[id] {
 
 .uni-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .uni-icon {
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -298,21 +298,21 @@ section[id] {
 
 .uni-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .uni-location {
     font-size: 14px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 600;
     margin-bottom: 15px;
 }
 
 .uni-desc {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     flex-grow: 1;
     margin-bottom: 20px;
@@ -320,24 +320,24 @@ section[id] {
 
 .learn-more {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     transition: 0.3s;
-    border-bottom: 2px solid #8d2123;
+    border-bottom: 2px solid var(--accent);
     padding-bottom: 4px;
 }
 
 .learn-more:hover {
-    color: #6a181b;
-    border-color: #6a181b;
+    color: var(--accent-dark);
+    border-color: var(--accent-dark);
 }
 
 /* ===== POPULAR COURSES SECTION ===== */
 
 .popular-courses {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .courses-grid {
@@ -347,8 +347,8 @@ section[id] {
 }
 
 .course-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px 20px;
     border-radius: 12px;
     text-align: center;
@@ -356,27 +356,27 @@ section[id] {
 }
 
 .course-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-6px);
     box-shadow: 0 15px 35px rgba(141, 33, 35, 0.12);
 }
 
 .course-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .course-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 10px;
     font-weight: 700;
 }
 
 .course-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -384,7 +384,7 @@ section[id] {
 
 .pte-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .pte-content {
@@ -394,22 +394,22 @@ section[id] {
 }
 
 .pte-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .pte-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .pte-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -421,14 +421,14 @@ section[id] {
 
 .pte-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .pte-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -436,7 +436,7 @@ section[id] {
 
 .intakes-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .intakes-timeline {
@@ -450,21 +450,21 @@ section[id] {
 .intake-item {
     display: flex;
     gap: 20px;
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .intake-item:hover {
     transform: translateX(8px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .intake-month {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     min-width: 80px;
     height: 80px;
@@ -479,14 +479,14 @@ section[id] {
 
 .intake-details h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 8px;
     font-weight: 700;
 }
 
 .intake-details p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -494,7 +494,7 @@ section[id] {
 
 .work-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .work-grid {
@@ -504,35 +504,35 @@ section[id] {
 }
 
 .work-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .work-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .work-card i {
     font-size: 38px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 18px;
 }
 
 .work-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .work-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -540,7 +540,7 @@ section[id] {
 
 .visa-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .visa-content {
@@ -552,29 +552,29 @@ section[id] {
 }
 
 .visa-box {
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
-    border: 1px solid #e8e8e8;
+    background: var(--bg-card);
+    border: 1px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .visa-box:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     box-shadow: 0 12px 30px rgba(141, 33, 35, 0.12);
 }
 
 .visa-box h3 {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
     font-weight: 700;
 }
 
 .visa-box p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -582,7 +582,7 @@ section[id] {
     list-style: none;
     padding: 0;
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.8;
 }
 
@@ -596,7 +596,7 @@ section[id] {
     content: "✓";
     position: absolute;
     left: 0;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: bold;
 }
 
@@ -604,7 +604,7 @@ section[id] {
 
 .cost-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cost-grid {
@@ -615,69 +615,69 @@ section[id] {
 }
 
 .cost-card {
-    background: white;
+    background: var(--bg-card);
     padding: 30px;
     border-radius: 12px;
     text-align: center;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .cost-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 16px 35px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .cost-card i {
     font-size: 36px;
-    color: #8d2123;
+    color: var(--accent);
     margin-bottom: 15px;
 }
 
 .cost-card h3 {
     font-size: 18px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .cost-amount {
     font-size: 20px;
-    color: #8d2123;
+    color: var(--accent);
     font-weight: 700;
     margin: 12px 0;
 }
 
 .cost-card p {
     font-size: 13px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
 .cost-summary {
-    background: white;
+    background: var(--bg-card);
     padding: 25px;
     border-radius: 12px;
     text-align: center;
-    border-left: 5px solid #8d2123;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    border-left: 5px solid var(--accent);
+    box-shadow: var(--shadow-soft);
 }
 
 .cost-summary p {
     font-size: 16px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin: 0;
 }
 
 .cost-summary strong {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 /* ===== SCHOLARSHIPS SECTION ===== */
 
 .scholarships-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .scholarships-grid {
@@ -687,8 +687,8 @@ section[id] {
 }
 
 .scholarship-card {
-    background: white;
-    border: 2px solid #f0f0f0;
+    background: var(--bg-card);
+    border: 2px solid var(--border-card);
     padding: 30px;
     border-radius: 12px;
     transition: all 0.3s ease;
@@ -696,14 +696,14 @@ section[id] {
 }
 
 .scholarship-card:hover {
-    border-color: #8d2123;
+    border-color: var(--accent);
     transform: translateY(-8px);
-    box-shadow: 0 16px 40px rgba(141, 33, 35, 0.12);
+    box-shadow: var(--shadow-lift);
 }
 
 .scholarship-badge {
     display: inline-block;
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     padding: 6px 14px;
     border-radius: 20px;
@@ -716,14 +716,14 @@ section[id] {
 
 .scholarship-card h3 {
     font-size: 20px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .scholarship-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
 }
 
@@ -731,7 +731,7 @@ section[id] {
 
 .cities-section {
     padding: 80px 20px;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .cities-grid {
@@ -741,22 +741,22 @@ section[id] {
 }
 
 .city-card {
-    background: white;
+    background: var(--bg-card);
     padding: 35px 28px;
     border-radius: 14px;
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .city-card:hover {
     transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lift);
 }
 
 .city-icon {
     width: 55px;
     height: 55px;
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -768,14 +768,14 @@ section[id] {
 
 .city-card h3 {
     font-size: 22px;
-    color: #1a1a1a;
+    color: var(--text-primary);
     margin-bottom: 12px;
     font-weight: 700;
 }
 
 .city-card p {
     font-size: 14px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.6;
     margin-bottom: 8px;
 }
@@ -784,7 +784,7 @@ section[id] {
 
 .facts-section {
     padding: 80px 20px;
-    background: white;
+    background: var(--bg-primary);
 }
 
 .facts-grid {
@@ -794,7 +794,7 @@ section[id] {
 }
 
 .fact-card {
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     color: white;
     padding: 30px 20px;
     border-radius: 12px;
@@ -835,7 +835,7 @@ section[id] {
 
 .faq-section {
     padding: 100px 20px;
-    background: linear-gradient(135deg, #f8f9fb, #ffffff);
+    background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
     position: relative;
 }
 
@@ -864,17 +864,17 @@ section[id] {
 .faq-item {
     border-radius: 12px;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.8);
+    background: var(--bg-faq-item);
     backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--border-card);
+    box-shadow: var(--shadow-soft);
     transition: all 0.3s ease;
 }
 
 .faq-item:hover {
     transform: translateY(-4px);
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
-    border-color: #8d2123;
+    box-shadow: var(--shadow-lift);
+    border-color: var(--accent);
 }
 
 .faq-question {
@@ -884,7 +884,7 @@ section[id] {
     background: transparent;
     font-size: 16px;
     font-weight: 600;
-    color: #1a1a1a;
+    color: var(--text-primary);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -894,7 +894,7 @@ section[id] {
 
 .faq-question i {
     font-size: 16px;
-    color: #8d2123;
+    color: var(--accent);
     transition: 0.3s;
 }
 
@@ -907,13 +907,13 @@ section[id] {
 
 .faq-answer p {
     padding: 15px 0 20px;
-    color: #555;
+    color: var(--text-muted);
     line-height: 1.7;
     font-size: 14px;
 }
 
 .faq-item.active .faq-question {
-    color: #8d2123;
+    color: var(--accent);
 }
 
 .faq-item.active .faq-question i {
@@ -928,7 +928,7 @@ section[id] {
 
 .cta-section {
     padding: 80px 20px;
-    background: linear-gradient(135deg, #8d2123, #b82e2e);
+    background: linear-gradient(135deg, var(--accent), #b82e2e);
     color: white;
     text-align: center;
 }
@@ -983,23 +983,23 @@ section[id] {
 .back-to-home {
     padding: 40px 20px;
     text-align: center;
-    background: #f7f7f7;
+    background: var(--bg-secondary);
 }
 
 .back-button {
     display: inline-block;
-    color: #8d2123;
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
     font-size: 16px;
     padding: 12px 24px;
-    border: 2px solid #8d2123;
+    border: 2px solid var(--accent);
     border-radius: 8px;
     transition: all 0.3s ease;
 }
 
 .back-button:hover {
-    background: #8d2123;
+    background: var(--accent);
     color: white;
     transform: translateX(-5px);
 }
@@ -1172,10 +1172,10 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #8d2123;
+    background: var(--accent);
     border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #6a181b;
+    background: var(--accent-dark);
 }


### PR DESCRIPTION
**Title:** Fix(uk): replace hardcoded colors with CSS variables for theme support
Closes: #114 

**Summary**
Refactors the  page stylesheet to fully respect the global dark/light theme toggle by replacing all static color values with the appropriate CSS variables from theme.css.

**Changes Made**

- Backgrounds – Replaced #ffffff backgrounds with --bg-primary and --bg-secondary for dynamic theming.
- Cards – Updated card backgrounds to use --bg-card for consistent styling across themes.
- Text Elements – Replaced hardcoded colors (#1a1a1a, #555, etc.) with --text-primary and --text-muted to ensure proper contrast.
- Accent Colors – Replaced hardcoded #8d2123 with --accent and its dark variant with --accent-dark for consistent brand color theming.
- Shadows – Applied --shadow-soft and --shadow-lift for dynamic shadow effects that adapt to the theme.
- Borders – Styled card borders with --border-card for consistent border theming.
- FAQ Items – Configured .faq-item elements to use --bg-faq-item and updated state/hover styling to respond to theme variables.
- Scrollbars – Ensured scrollbar styles are adaptive to the active theme.

**Testing Performed**
- Toggled between light and dark modes to verify all backgrounds, cards, text, borders, and shadows render with correct contrast and styling.
- Confirmed FAQ items display properly in both themes with correct hover states.
- Verified scrollbar styling adapts to the active theme.
- Checked responsive behaviour on desktop and mobile to ensure no layout regressions.

## Screenshot
<img width="1902" height="893" alt="image" src="https://github.com/user-attachments/assets/7517d2ec-3253-4865-9cd3-04da388264e1" />
<img width="1905" height="876" alt="image" src="https://github.com/user-attachments/assets/cda7d3a0-d1f2-4930-902f-1ce30976c8ae" />
