### PR TITLE
feat(backend): [Task 17] Add user profiles schema and model

### DIFF
--- a/back-end/src/docs/user-profiles-schema.md
+++ b/back-end/src/docs/user-profiles-schema.md
@@ -1,0 +1,27 @@
+# User Profiles Schema
+
+## Table Name
+
+user_profiles
+
+## Fields
+
+| Field | Type | Description |
+|---------|---------|---------|
+| user_id | UUID | Unique identifier of the user |
+| target_score | INTEGER | Desired PTE score |
+| test_date | DATE | Planned PTE exam date |
+| country_applying_to | STRING | Country user is applying to |
+| visa_type | STRING | Visa category |
+| streak_days | INTEGER | Consecutive study days |
+| last_active | DATE | Last activity timestamp |
+
+## Purpose
+
+Stores profile information and study progress metadata for users.
+
+## Notes
+
+- One profile belongs to one user.
+- streak_days tracks learning consistency.
+- last_active helps monitor engagement.

--- a/back-end/src/models/UserProfile.js
+++ b/back-end/src/models/UserProfile.js
@@ -1,0 +1,51 @@
+const { DataTypes } = require("sequelize");
+
+module.exports = (sequelize) => {
+  const UserProfile = sequelize.define(
+    "UserProfile",
+    {
+      user_id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+      },
+
+      target_score: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+
+      test_date: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+
+      country_applying_to: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+
+      visa_type: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+
+      streak_days: {
+        type: DataTypes.INTEGER,
+        defaultValue: 0,
+        allowNull: false,
+      },
+
+      last_active: {
+        type: DataTypes.DATE,
+        defaultValue: DataTypes.NOW,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: "user_profiles",
+      timestamps: false,
+    }
+  );
+
+  return UserProfile;
+};


### PR DESCRIPTION
## Summary

Implemented Task 17: Design user_profiles table.

### Changes Made

* Added `user_profiles` schema documentation.
* Added Sequelize `UserProfile` model.
* Included fields:

  * `user_id`
  * `target_score`
  * `test_date`
  * `country_applying_to`
  * `visa_type`
  * `streak_days`
  * `last_active`

### Files Added

* `back-end/src/docs/user-profiles-schema.md`
* `back-end/src/models/UserProfile.js`

### Notes

This schema stores user profile information and study progress metadata for future backend integration.

Related to #72 