### PR TITLE
Fix #172: Cleaned up CSS to make headings black in both themes and re…

### DIFF
--- a/styles/css/legal.css
+++ b/styles/css/legal.css
@@ -165,10 +165,10 @@
 .legal-section h2 {
     font-size: clamp(1.25rem, 2.5vw, 1.6rem);
     font-weight: 700;
-    color: var(--text-primary, #1a1a1a);
+    color: #000000;
     margin: 0 0 16px;
     padding-bottom: 10px;
-    border-bottom: 2px solid rgba(141, 33, 35, 0.12);
+    border-bottom: 2px solid rgba(0, 0, 0, 0.2);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -190,7 +190,7 @@
 .legal-section h3 {
     font-size: 1.05rem;
     font-weight: 700;
-    color: var(--text-primary, #1a1a1a);
+    color: #000000;
     margin: 24px 0 8px;
 }
 


### PR DESCRIPTION
## 📋 Pull Request — Force Black Section Headings in Both Themes & Remove Duplicate CSS

### 🔗 Related Issue
Closes #172 — *[Bug] Section headings are unreadable / have poor contrast in Dark Mode on Disclaimer page*

---

### 📝 Summary
The Disclaimer page's section headings (`h2` and `h3`) had poor contrast in Dark Mode, making them extremely hard to read. This PR completely resolves the issue by forcing both Light Mode and Dark Mode headings to be Pure Black (`#000000`). Alongside this fix, duplicate CSS rules have been removed to ensure a clean, maintainable codebase.

---

### 🐛 Root Causes Identified

| # | Problem | Fix Applied |
|---|---------|------------|
| 1 | `.legal-section h2` used `var(--text-primary, #1a1a1a)` which became light grey in Dark Mode, causing low contrast | Hardcoded to pure `#000000` for both themes |
| 2 | Overlapping and duplicate CSS blocks for headings and icons at the bottom of the file | Removed duplicate block and merged clean rules into the main section |

---

### ✅ Changes Made

#### Modified Files
| File | What Changed |
|------|-------------|
| `styles/css/legal.css` | Updated `color` of `.legal-section h2` and `.legal-section h3` to `#000000`; updated border to `rgba(0, 0, 0, 0.2)`; cleaned up the CSS structure by removing the duplicate `/* ===== FIX #172 ===== */` block at the bottom |

---

### 🎨 UI/UX & Code Quality Improvements

- **High Contrast Headings** — Headings are now pure black (`#000000`) in both Light and Dark modes, ensuring they are unmistakably visible at all times.
- **Darkened Bottom Borders** — Updated the section border from a red-tinted grey to a pure dark shade `rgba(0, 0, 0, 0.2)` for a seamless, premium look.
- **Preserved Icon Contrast** — The icon next to the heading remains your brand Red (`var(--accent)`) to provide a subtle visual anchor against the black text.
- **Removed Duplicate Code** — Eliminated unnecessary `!important` overrides and redundant CSS blocks. This follows the DRY (Don't Repeat Yourself) principle and makes future styling much easier.

---

### 🧪 Testing Checklist

- [ ] `h2` headings in the Legal/Disclaimer page appear pure black in **Light Mode**
- [ ] `h2` headings in the Legal/Disclaimer page appear pure black in **Dark Mode**
- [ ] `h3` sub-headings also adhere to the pure black color in both themes.
- [ ] Icon next to the heading remains the brand accent color (red).
- [ ] The bottom border of the heading is clearly visible.
- [ ] No duplicate CSS definitions or console warnings in the DevTools.
- [ ] Layout remains unchanged and responsive on mobile devices.

---

### 📸 Screenshots
<img width="1863" height="898" alt="image" src="https://github.com/user-attachments/assets/452029cd-723e-4742-a480-a3d033ad913f" />

---

### 💻 How to Test Locally

```bash
# Navigate to the project folder
cd ptet-web

# Serve with Python
python -m http.server 8000

# Open in browser
http://localhost:8000/pages/disclaimer.html