### PR TITLE
Fix #190: Replaced fixed width/height of intake month badge with dyna…

### DIFF
--- a/styles/css/australia.css
+++ b/styles/css/australia.css
@@ -512,6 +512,7 @@ section[id] {
 
 .intake-item {
     display: flex;
+    flex-direction: column;
     gap: 20px;
     background: var(--bg-card);
     padding: 25px;
@@ -529,18 +530,23 @@ section[id] {
 .intake-month {
     background: var(--accent);
     color: white;
-    min-width: 80px;
-    height: 80px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    min-width: auto;
+    width: auto;
+    height: auto;
+    padding: 16px 20px;
     border-radius: 8px;
     font-weight: 700;
     font-size: 18px;
     text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .intake-details h3 {
+    text-align: center;
     font-size: 20px;
     color: var(--text-primary);
     margin-bottom: 8px;
@@ -548,6 +554,7 @@ section[id] {
 }
 
 .intake-details p {
+    text-align: center;
     font-size: 14px;
     color: var(--text-muted);
     line-height: 1.6;
@@ -1152,20 +1159,21 @@ section[id] {
         grid-template-columns: 1fr;
     }
 
-    .intakes-timeline {
-        grid-template-columns: 1fr;
-    }
+ .intakes-timeline {
+     grid-template-columns: 1fr;
+ }
 
-    .intake-item {
-        flex-direction: column;
-    }
+ .intake-item {
+     flex-direction: column;
+     align-items: flex-start;
+ }
 
-    .intake-month {
-        width: 100%;
-        min-width: unset;
-        height: auto;
-        padding: 12px;
-    }
+ .intake-month {
+     width: auto;
+     min-width: unset;
+     height: auto;
+     padding: 12px 16px;
+ }
 
     .cta-content h2 {
         font-size: 32px;


### PR DESCRIPTION
## 📋 Pull Request — Fix Month Badge Overflow on Australia Page

### 🔗 Related Issue
Closes #190 — *[UI] Text overflows inside the month badge on University Intake cards for longer month names*

### ✅ Changes Made
- Updated `australia.css` to remove fixed `min-width: 80px` and `height: 80px` from the `.intake-month` class.
- Applied `width: auto`, `height: auto`, `padding: 16px 20px`, and `white-space: nowrap` to allow the badge to dynamically resize based on the month name length.
- Added `flex-shrink: 0` to prevent the badge from getting squashed on mobile screens.
- Updated the mobile responsive media query to ensure the badge remains clean on small screens.

### 🧪 Testing Checklist
- [ ] "November", "February", etc. are fully visible inside the badge without overflow.
- [ ] Badge automatically expands/contracts based on text length.
- [ ] Responsive and looks correct on desktop, tablet, and mobile.

##screenshot
<img width="1902" height="912" alt="image" src="https://github.com/user-attachments/assets/4828df15-a8ea-4a9f-a1bc-dec4de630e7a" />
