### PR TITLE
Fix #192: Applied dynamic sizing to intake month badge on desktop vie…

### DIFF
--- a/styles/css/uk.css
+++ b/styles/css/uk.css
@@ -448,6 +448,7 @@ section[id] {
 
 .intake-item {
     display: flex;
+    flex-direction: column;
     gap: 20px;
     background: var(--bg-card);
     padding: 25px;
@@ -464,19 +465,24 @@ section[id] {
 
 .intake-month {
     background: var(--accent);
-    color: white;
-    min-width: 80px;
-    height: 80px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 8px;
-    font-weight: 700;
-    font-size: 18px;
-    text-align: center;
+        color: white;
+        min-width: auto;
+        width: auto;
+        height: auto;
+        padding: 16px 24px;
+        border-radius: 8px;
+        font-weight: 700;
+        font-size: 18px;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        flex-shrink: 0;
 }
 
 .intake-details h3 {
+    text-align: center;
     font-size: 20px;
     color: var(--text-primary);
     margin-bottom: 8px;
@@ -484,6 +490,7 @@ section[id] {
 }
 
 .intake-details p {
+    text-align: center;
     font-size: 14px;
     color: var(--text-muted);
     line-height: 1.6;


### PR DESCRIPTION
## 📋 Pull Request — Fix Month Badge Overflow on UK Page

### 🔗 Related Issue
Closes #192 — *[UI] Month badge text overflows on UK University Intake cards for longer month names (e.g., "September")*

### ✅ Changes Made
- Removed the fixed `min-width: 80px` and `height: 80px` from the desktop `.intake-month` class in `uk.css`.
- Implemented `width: auto`, `height: auto`, `padding: 16px 24px`, and `white-space: nowrap` to make the badge dynamically adapt to text lengths.
- Added `flex-shrink: 0` to prevent the badge from being squashed on small screens.
- The existing mobile media query override was left intact to properly handle mobile layouts.

### 🧪 Testing Checklist
- [ ] "September" (and other long names) are fully visible inside the red badge without clipping.
- [ ] Badge automatically expands for longer text and contracts for shorter text.
- [ ] Responsive and looks correct on desktop, tablet, and mobile.


## screenshot

<img width="1902" height="906" alt="image" src="https://github.com/user-attachments/assets/e2f8a286-e4a7-4462-b3fe-4e71e23a2841" />

