### PR TITLE
Fix #193: Redesigned UK Quick Facts cards with premium light backgrou…

### DIFF
--- a/styles/css/uk.css
+++ b/styles/css/uk.css
@@ -793,42 +793,89 @@ section[id] {
 }
 
 .fact-card {
-    background: linear-gradient(135deg, var(--accent), #b82e2e);
-    color: white;
+    background: var(--bg-card);
+    color: var(--text-primary);
     padding: 30px 20px;
-    border-radius: 12px;
+    border-radius: 16px;
     text-align: center;
-    box-shadow: 0 8px 20px rgba(141, 33, 35, 0.2);
-    transition: all 0.3s ease;
+    border: 1px solid var(--border-card);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+    transition: all 0.35s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.fact-card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--accent), #b82e2e);
+    border-radius: 16px 16px 0 0;
+}
+
+.fact-card::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(120deg, transparent, rgba(141, 33, 35, 0.06), transparent);
+    transition: 0.5s ease;
+}
+
+.fact-card:hover::after {
+    left: 100%;
 }
 
 .fact-card:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 16px 35px rgba(141, 33, 35, 0.3);
+    transform: translateY(-8px);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.12);
+    border-color: var(--accent);
 }
 
 .fact-icon {
-    width: 50px;
-    height: 50px;
-    background: rgba(255, 255, 255, 0.2);
+    width: 54px;
+    height: 54px;
+    background: rgba(141, 33, 35, 0.1);
+    border: 1.5px solid rgba(141, 33, 35, 0.2);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 24px;
-    margin: 0 auto 15px;
+    font-size: 22px;
+    color: var(--accent);
+    margin: 0 auto 16px;
+    transition: all 0.3s ease;
+}
+
+.fact-card:hover .fact-icon {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+    box-shadow: 0 6px 18px rgba(141, 33, 35, 0.35);
 }
 
 .fact-card h3 {
-    font-size: 16px;
-    margin-bottom: 10px;
+    font-size: 14px;
     font-weight: 700;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
 }
 
 .fact-card p {
-    font-size: 14px;
-    opacity: 0.95;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.5;
 }
+
+
 
 /* ===== FAQ SECTION ===== */
 


### PR DESCRIPTION
## 📋 Pull Request — Redesign UK Quick Facts Cards with Premium UI

### 🔗 Related Issue
Closes #193 — *[UI] Redesign "Quick Facts About United Kingdom" cards with a modern premium UI*

### ✅ Changes Made
- Replaced the heavy solid dark red gradient background with a clean white/light background (`var(--bg-card)`).
- Added a `3px` red gradient accent border to the top of each card to maintain brand identity.
- Added soft premium shadows (`box-shadow`) for depth.
- Enhanced the icon styling (subtle red background turns fully red with a white symbol on hover).
- Added smooth animations: `translateY(-8px)` lift, hover shadow increase, and a subtle "shine" sweep effect.
- Improved typography visibility with high contrast in both Light and Dark modes.

### 🧪 Testing Checklist
- [ ] Cards use a clean white/light background instead of a heavy red.
- [ ] Red accent top border is clearly visible.
- [ ] Cards have a soft premium shadow and smooth lift animation on hover.
- [ ] Icon background transitions smoothly to solid red on hover.
- [ ] Typography and icons are perfectly visible and properly centered.
- [ ] Fully responsive on desktop, tablet, and mobile.

## screenshot

<img width="1895" height="911" alt="image" src="https://github.com/user-attachments/assets/9f3a8bf6-3038-4f79-b5e9-06fbe9e11dac" />
