### PR TITLE
Fix #212: Execute centralized environment validation at application s…

### DIFF
--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -4,7 +4,8 @@ const helmet = require('helmet');
 const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
 const errorHandler = require('./middleware/errorHandler');
-
+const {validateEnv}  =  require("./config/envValidator");
+validateEnv();
 const app = express();
 
 // Middleware

--- a/back-end/src/config/envValidator.js
+++ b/back-end/src/config/envValidator.js
@@ -1,0 +1,33 @@
+
+const REQUIRED_ENV_VARS = [
+  'NODE_ENV',
+  'PORT',
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'DB_HOST',
+  'DB_PORT',
+  'DB_NAME',
+  'DB_USER',
+  'DB_PASSWORD',
+  'REDIS_HOST',
+  'REDIS_PORT',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+];
+
+const validateEnv = () => {
+  const missingVars = REQUIRED_ENV_VARS.filter((varName) => {
+    const value = process.env[varName];
+    return !value || value.trim() === '';
+  });
+
+  if (missingVars.length > 0) {
+    console.error('❌ Environment Validation Failed: Missing required environment variables.');
+    console.error(`   Missing: ${missingVars.join(', ')}`);
+    console.error('   Please check your .env file and ensure all required variables are set.');
+    process.exit(1); 
+  }
+
+  console.log('✅ Environment Variables Validation Passed.');
+};
+
+module.exports = { validateEnv };


### PR DESCRIPTION
## 📋 Pull Request — Implement Environment Variable Validation at Startup

### 🔗 Related Issue
Closes #212 — *Add Environment Variable Validation During Application Startup*

### ✅ Changes Made
- **Centralized Validation:** Imported the `validateEnv` utility from `./config/envValidator.js`.
- **Execution Fix:** Added the `validateEnv()` function call at the very beginning of the middleware chain, before the Express app initialization.
- **Prevent Runtime Failures:** Ensures that if any required environment variables (`NODE_ENV`, `PORT`, `JWT_SECRET`, DB credentials, etc.) are missing, the server will gracefully exit with a clear error message instead of failing later at runtime.

### 🧪 Testing Checklist
- [ ] Run `npm start` with a complete `.env` file. (The app should start successfully and log `✅ Environment Variables Validation Passed.`)
- [ ] Run `npm start` after removing a crucial variable (like `JWT_SECRET`) from `.env`. (The app should stop immediately with a clear error listing the missing variable.)

### 📌 Benefits Achieved
- ✅ Prevents cryptic runtime configuration errors.
- ✅ Makes application startup much more reliable and robust.
- ✅ Provides immediate feedback to developers about missing configurations.