### PR TITLE
Replace Console Statements with Centralized Logger in Graceful Shutdown Utility

### DIFF
--- a/back-end/src/utils/gracefulshutdown.js
+++ b/back-end/src/utils/gracefulshutdown.js
@@ -1,31 +1,30 @@
-// src/utils/gracefulShutdown.js
 const mongoose = require('mongoose');
+const logger = require('./serverLogger');
 
 const gracefulShutdown = (server, signal) => {
-  console.log(`Received ${signal}. Starting graceful shutdown...`);
+  logger.info(`Received ${signal}. Starting graceful shutdown...`);
 
   const shutdownTimeout = setTimeout(() => {
-    console.error('Shutdown timeout. Forcefully exiting...');
+    logger.error('Shutdown timeout. Forcefully exiting...');
     process.exit(1);
   }, 10000);
 
   server.close(async () => {
     clearTimeout(shutdownTimeout);
-    console.log('Closing MongoDB connection...');
+    logger.info('Closing MongoDB connection...');
 
     try {
       await mongoose.connection.close();
-      console.log('MongoDB connection closed.');
-      console.log('Server shut down gracefully.');
+      logger.info('MongoDB connection closed.');
+      logger.info('Server shut down gracefully.');
       process.exit(0);
     } catch (err) {
-      console.error(`Error during shutdown: ${err.message}`);
+      logger.error(`Error during shutdown: ${err.message}`);
       process.exit(1);
     }
   });
 };
 
-// एक्सपोर्ट फंक्शन जो सिग्नल्स को अटैच करता है
 const setupGracefulShutdown = (server) => {
   ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach((signal) => {
     process.on(signal, () => {


### PR DESCRIPTION
## 📋 Pull Request — Replace Console Statements with Centralized Logger in Graceful Shutdown Utility

### 🔗 Related Issue
Closes #262 — *Replace Console Statements with Centralized Logger in Graceful Shutdown Utility*

### ✅ Changes Made
- Imported the centralized `logger` from `./serverLogger` into `src/utils/gracefulShutdown.js`.
- Replaced all `console.log` instances with `logger.info()`.
- Replaced all `console.error` instances with `logger.error()`.
- Preserved the exact same log messages and graceful shutdown logic.
- No changes to the existing graceful shutdown functionality or behavior.

### 🧪 Testing Checklist
- [ ] Shutting down the server via `Ctrl + C` triggers the graceful shutdown sequence.
- [ ] All logs during shutdown now go through the centralized logger (`logger.info` and `logger.error`).
- [ ] The log format is consistent with the rest of the application.
- [ ] No existing functionality is broken.

### 📌 Benefits Achieved
- ✅ **Consistent logging format** across the entire application.
- ✅ **Easier debugging** and centralized log management.