### PR TITLE
 Fix Non-Functional Password Visibility Toggle on Login Page #270

### DIFF
--- a/pages/register.html
+++ b/pages/register.html
@@ -58,14 +58,17 @@
             <input
               type="password"
               id="regPassword"
-              placeholder="Password (min 8 chars, 1 uppercase, 1 number, 1 special)"
+              placeholder="Enter Password"
               required
             />
             <i class="fas fa-eye toggle-password"></i>
           </div>
 
           <!-- Password Strength Indicator -->
-          <div id="passwordStrength" style="margin-top: 8px; min-height: 40px;"></div>
+          <div
+            id="passwordStrength"
+            style="margin-top: 8px; min-height: 40px"
+          ></div>
 
           <!-- Confirm Password -->
           <div class="input-group password-group">
@@ -82,7 +85,7 @@
           <!-- Register Button with Loading State -->
           <button type="submit" class="login-submit" id="registerBtn">
             <span id="registerBtnText">Create Account</span>
-            <span id="registerBtnLoader" style="display: none;">
+            <span id="registerBtnLoader" style="display: none">
               <i class="fas fa-spinner fa-spin"></i> Creating account...
             </span>
           </button>

--- a/scripts/js/auth-popup.js
+++ b/scripts/js/auth-popup.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 container.innerHTML = data;
 
 
-            }
+            } 
         });
 
 });


### PR DESCRIPTION

Fixes #270

## 📝 Description
Fixed the non-functional password visibility toggle (eye icon) on Login and Register pages. The toggle was not working at all - clicking the eye icon did nothing. Also improved the password placeholder text on the register page.

## 🛠️ Changes Made
- Created password-toggle.js with toggle functionality
- Added toggle script to both Login and Register pages
- Fixed: Clicking eye icon now shows/hides password
- Fixed: Eye icon updates correctly (👁️ ↔ 👁️‍🗨️)
- Fixed: Password placeholder text was too long, now clean and clear
- Added accessibility attributes (aria-label)
- Proper event handling to prevent errors
