### PR TITLE
fix(mock-tests): add validation and sanitization for test filter queries

### DIFF
--- a/back-end/src/controllers/mockTestController.js
+++ b/back-end/src/controllers/mockTestController.js
@@ -7,7 +7,7 @@ exports.getTests = async (req, res, next) => {
 
     if (type) filter.type = type;
     if (difficulty) filter.difficulty = difficulty;
-    if (duration) filter.duration_minutes = duration;
+    if (duration !== undefined) filter.duration_minutes = duration;
 
     const tests = await MockTest.findAll({
       where: filter,

--- a/back-end/src/middleware/validators/mockTest.validator.js
+++ b/back-end/src/middleware/validators/mockTest.validator.js
@@ -1,0 +1,34 @@
+const { query } = require('express-validator');
+const { handleValidationErrors } = require('../middlewares/validation');
+
+const ALLOWED_TEST_TYPES = ['subject', 'chapter', 'full-length'];
+const ALLOWED_DIFFICULTIES = ['easy', 'medium', 'hard'];
+
+exports.validateGetTests = [
+  query('type')
+    .optional()
+    .trim()
+    .toLowerCase()
+    .isIn(ALLOWED_TEST_TYPES)
+    .withMessage(
+      `type must be one of: ${ALLOWED_TEST_TYPES.join(', ')}`
+    ),
+
+  query('difficulty')
+    .optional()
+    .trim()
+    .toLowerCase()
+    .isIn(ALLOWED_DIFFICULTIES)
+    .withMessage(
+      `difficulty must be one of: ${ALLOWED_DIFFICULTIES.join(', ')}`
+    ),
+
+  query('duration')
+    .optional()
+    .trim()
+    .isInt({ min: 1 })
+    .withMessage('duration must be a positive integer')
+    .toInt(),
+
+  handleValidationErrors,
+];

--- a/back-end/src/routes/mockTestRoutes.js
+++ b/back-end/src/routes/mockTestRoutes.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const mockTestController = require('../controllers/mockTestController');
+const {validateGetTests} = require("../middleware/validators/mockTest.validator")
 
-router.get('/', mockTestController.getTests);
+router.get('/', validateGetTests ,mockTestController.getTests);
 router.get('/:id', mockTestController.getTestById);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Added validation and sanitization for mock test filter query parameters in the `getTests` endpoint.

## Changes made

* Added centralized validation middleware for mock test filters
* Validated `type` against allowed mock test types
* Validated `difficulty` against allowed difficulty levels
* Validated `duration` as a positive integer and converted it to a number before use
* Updated `getTests` to use sanitized query values when building the database filter

## Benefits

* Prevents malformed filter values from reaching the database layer
* Ensures consistent `400` responses for invalid query parameters
* Keeps controller logic clean and focused on data retrieval

## Issue fixed

Closes #303
