### PR TITLE
fix(saved-materials): validate user and material route params

### DIFF
--- a/back-end/src/controllers/savedMaterialController.js
+++ b/back-end/src/controllers/savedMaterialController.js
@@ -1,55 +1,41 @@
 const { SavedMaterial, StudyMaterial } = require('../models');
 const response = require('../utils/response');
 
-/**
- * POST /api/users/:id/saved/:materialId
- * Toggle bookmark: add if not saved, remove if already saved.
- */
 exports.toggleSave = async (req, res, next) => {
   try {
-    const userId = req.params.id;
-    const materialId = req.params.materialId;
+    const userId = Number(req.params.id);
+    const materialId = req.params.materialId ? Number(req.params.materialId) : undefined;
 
-    // Authorization: only the user themselves or an admin can modify
-    if (req.user.id !== userId && req.user.role !== 'admin') {
+    if (Number(req.user.id) !== userId && req.user.role !== 'admin') {
       return response.error(res, 'Unauthorized to modify saved materials for this user', 403);
     }
 
-    // Check if the material exists
     const material = await StudyMaterial.findByPk(materialId);
     if (!material) {
       return response.error(res, 'Material not found', 404);
     }
 
-    // Check current bookmark status
     const existing = await SavedMaterial.findOne({
       where: { user_id: userId, material_id: materialId },
     });
 
     if (existing) {
-      // Unsave
       await existing.destroy();
       return response.success(res, null, 'Material unsaved (removed from bookmarks)');
-    } else {
-      // Save
-      await SavedMaterial.create({ user_id: userId, material_id: materialId });
-      return response.success(res, null, 'Material saved (added to bookmarks)');
     }
+
+    await SavedMaterial.create({ user_id: userId, material_id: materialId });
+    return response.success(res, null, 'Material saved (added to bookmarks)');
   } catch (err) {
     next(err);
   }
 };
 
-/**
- * GET /api/users/:id/saved
- * List all bookmarked materials for a user.
- */
 exports.getSavedMaterials = async (req, res, next) => {
   try {
-    const userId = req.params.id;
-
-    // Authorization: only the user themselves or an admin can view
-    if (req.user.id !== userId && req.user.role !== 'admin') {
+    const userId = Number(req.params.id);
+    
+    if (Number(req.user.id) !== userId && req.user.role !== 'admin') {
       return response.error(res, 'Unauthorized to view saved materials for this user', 403);
     }
 
@@ -58,13 +44,21 @@ exports.getSavedMaterials = async (req, res, next) => {
       include: [
         {
           model: StudyMaterial,
-          attributes: ['id', 'title', 'description', 'type', 'skill', 'content_url', 'is_premium', 'created_at'],
+          attributes: [
+            'id',
+            'title',
+            'description',
+            'type',
+            'skill',
+            'content_url',
+            'is_premium',
+            'created_at',
+          ],
         },
       ],
       order: [['saved_at', 'DESC']],
     });
 
-    // Extract the material objects from the join
     const materials = savedRecords.map((record) => record.StudyMaterial);
 
     return response.success(res, materials, 'Saved materials retrieved');

--- a/back-end/src/middleware/validators/savedMaterial.validator.js
+++ b/back-end/src/middleware/validators/savedMaterial.validator.js
@@ -1,0 +1,19 @@
+const { param } = require('express-validator');
+const { handleValidationErrors } = require('../middlewares/validation');
+
+exports.validateSavedMaterialParams = [
+  param('id')
+    .trim()
+    .isInt({ min: 1 })
+    .withMessage('id must be a positive integer')
+    .toInt(),
+
+  param('materialId')
+    .optional()
+    .trim()
+    .isInt({ min: 1 })
+    .withMessage('materialId must be a positive integer')
+    .toInt(),
+
+  handleValidationErrors,
+];

--- a/back-end/src/routes/savedMaterialRoutes.js
+++ b/back-end/src/routes/savedMaterialRoutes.js
@@ -2,14 +2,15 @@ const express = require('express');
 const router = express.Router({ mergeParams: true });
 const savedMaterialController = require('../controllers/savedMaterialController');
 const { authenticate } = require('../middleware/authMiddleware');
+const {validateSavedMaterialParams} = require("../middleware/validators/savedMaterial.validator");
 
 // All routes require authentication
 router.use(authenticate);
 
 // POST /api/users/:id/saved/:materialId
-router.post('/:materialId', savedMaterialController.toggleSave);
+router.post('/:materialId', validateSavedMaterialParams ,savedMaterialController.toggleSave);
 
 // GET /api/users/:id/saved
-router.get('/', savedMaterialController.getSavedMaterials);
+router.get('/', validateSavedMaterialParams ,savedMaterialController.getSavedMaterials);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Added route parameter validation for saved materials endpoints to prevent malformed IDs from reaching authorization and database logic.

## Changes made

* Added validation middleware for `id` and `materialId` route parameters
* Enforced positive integer validation for saved materials route params
* Applied the validator to both:

  * toggle save endpoint
  * get saved materials endpoint
* Normalized controller param handling to use numeric IDs consistently in authorization and database queries

## Benefits

* Returns `400 Bad Request` for malformed route parameters
* Prevents invalid IDs from reaching the ORM layer
* Makes error behavior more predictable and improves controller safety

## Issue fixed

Closes #305
