### PR TITLE
fix: restore missing expand/collapse icon in FAQ toggle button #318

### DIFF
--- a/styles/css/australia.css
+++ b/styles/css/australia.css
@@ -1012,12 +1012,29 @@ section[id] {
     transition: 0.3s;
 }
 
-.faq-question i,
+/* .faq-question i,
 .faq-question span {
     font-size: 16px;
     color: var(--accent);
     transition: 0.3s;
+} */
+
+/* ✅ Fix: Restore the red circle and +/- icon */
+.faq-question span {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent);
+    color: white;
+    border-radius: 50%;
+    font-size: 18px;
+    transition: 0.3s;
+    flex-shrink: 0;
+    font-weight: 400;
 }
+
 
 .faq-answer {
     max-height: 0;


### PR DESCRIPTION
## Description
Closes #318

Fixed the missing expand/collapse icon in the FAQ toggle button. The previous `australia.css` override was stripping away the circular styling required for the `<span>` element, causing the button to appear as an empty red circle.

## Changes Made
- Updated `styles/css/australia.css`:
  - Reinstated the CSS for `.faq-question span` to include `width`, `height`, `border-radius`, `background`, and `display: flex` to correctly render the red circle and the `+` icon.
  - Changed the active state rotation selector from `.faq-question i` to `.faq-question span` to match the HTML tag correctly.
- The icon now correctly rotates from `+` to `×` (180 degrees) when the FAQ item is expanded and collapses back when clicked again.

## Benefits
- ✅ **Icon restored**: The expand/collapse icon inside the red toggle button is now clearly visible.
- ✅ **Intact functionality**: FAQ accordion continues to expand and collapse perfectly.
- ✅ **Consistent styling**: Maintains the premium UI design across the Australia page.