### PR TITLE
fix: restore missing expand/collapse icon in Canada page FAQ toggle b…

### DIFF
--- a/styles/css/canada.css
+++ b/styles/css/canada.css
@@ -951,8 +951,26 @@ section[id] {
     transition: 0.3s;
 }
 
-.faq-question i,
+/* ✅ FIX: Red circle aur icon restore kar diya */
 .faq-question span {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent);
+    /* Red circle background */
+    color: white;
+    /* White '+' icon */
+    border-radius: 50%;
+    /* Make it a perfect circle */
+    font-size: 18px;
+    transition: 0.3s;
+    flex-shrink: 0;
+    font-weight: 400;
+}
+
+.faq-question i {
     font-size: 16px;
     color: var(--accent);
     transition: 0.3s;


### PR DESCRIPTION
## Description
Closes #343

Fixed the missing expand/collapse icon in the FAQ toggle button on the Canada page. The CSS styling for the `<span>` element was incomplete, resulting in empty red circles instead of the `+`/`-` (or rotated) icon. This aligns it with the fix previously applied to the Australia page (#318).

## Changes Made
- Updated `styles/css/canada.css`:
  - Removed the generic `.faq-question i, .faq-question span` selector.
  - Added dedicated styling for `.faq-question span` to include:
    - `width: 32px` and `height: 32px`.
    - `display: flex; align-items: center; justify-content: center;` to center the `+` icon.
    - `background: var(--accent);` to create the red circle.
    - `border-radius: 50%;` to make it perfectly round.
    - `color: white;` to make the icon clearly visible.
  - The existing rotation logic inside `faq-item.active` is preserved, ensuring the icon rotates from `+` to `x` when expanded.

## Benefits
- ✅ **Icon restored**: The red circle now clearly shows the expand/collapse `+` icon.
- ✅ **Consistent UI**: Matches the exact look and behavior of the Australia page.
- ✅ **Improved UX**: Users can immediately recognize the interactive toggle mechanism.

## screenshot
<img width="1708" height="972" alt="image" src="https://github.com/user-attachments/assets/ec3977f5-ff4d-4428-b43a-514510912b7e" />
