### PR TITLE
fix(auth): normalize email addresses across authentication flows

### DIFF
--- a/back-end/src/controllers/authController.js
+++ b/back-end/src/controllers/authController.js
@@ -6,12 +6,13 @@ const admin = require('../config/firebase');
 const redis = require('../config/redis');
 const { cookieOptions } = require('../config/cookieConfig');
 const { JWT_SECRET, JWT_REFRESH_SECRET } = require('../config/env');
+const normalizeEmail = require("../utils/normalizeEmail");
 
 exports.register = async (req, res, next) => {
   try {
-    const { email, password, name } = req.body;
-
-    const trimmedEmail = email?.trim() || '';
+    const { password, name } = req.body;
+    const email = normalizeEmail(req.body.email)
+ 
     const trimmedPassword = password?.trim() || '';
     const trimmedName = name?.trim() || '';
 
@@ -21,7 +22,7 @@ exports.register = async (req, res, next) => {
       });
     }
 
-    const existingUser = await User.findOne({ where: { email:trimmedEmail } });
+    const existingUser = await User.findOne({ where: { email } });
     if (existingUser) {
       return res.status(200).json({
         message: 'If an account can be created, you will receive further instructions.',
@@ -34,7 +35,7 @@ exports.register = async (req, res, next) => {
     const verification_token = crypto.randomBytes(32).toString('hex');
 
     const user = await User.create({
-      email: trimmedEmail,
+      email,
       name: trimmedName,
       password_hash,
       provider: 'email',
@@ -58,7 +59,8 @@ exports.register = async (req, res, next) => {
 
 exports.login = async (req, res, next) => {
   try {
-    const { email, password } = req.body;
+    const { password } = req.body;
+    const email = normalizeEmail(req.body.email);
 
     const user = await User.findOne({ where: { email } });
     if (!user) {
@@ -109,7 +111,8 @@ exports.googleAuth = async (req, res, next) => {
     const { token } = req.body;
 
     const decodedToken = await admin.auth().verifyIdToken(token);
-    const { email, name, picture } = decodedToken;
+    const email = normalizeEmail(decodedToken.email);
+    const { name, picture } = decodedToken;
 
     if (!email) {
       return res.status(400).json({ error: 'No email associated with this token' });
@@ -169,7 +172,8 @@ exports.githubAuth = async (req, res, next) => {
     }
 
     const decodedToken = await admin.auth().verifyIdToken(token);
-    const { email, name, picture } = decodedToken;
+    const email = normalizeEmail(decodedToken.email);
+    const { name, picture } = decodedToken;
 
     if (!email) {
       return res.status(400).json({ error: 'No email associated with this token' });

--- a/back-end/src/utils/normalizeEmail.js
+++ b/back-end/src/utils/normalizeEmail.js
@@ -1,0 +1,5 @@
+function normalizeEmail(email) {
+  return email?.trim().toLowerCase() || "";
+}
+
+module.exports = normalizeEmail;


### PR DESCRIPTION
## Summary

This PR standardizes email normalization across all authentication flows by introducing a shared email normalization helper and using it consistently before user lookup and account creation.

## Changes made

* Added a shared `normalizeEmail()` utility
* Normalized email addresses in the `register` flow before lookup and persistence
* Normalized email addresses in the `login` flow before database lookup
* Normalized Firebase email addresses in the `googleAuth` flow
* Normalized Firebase email addresses in the `githubAuth` flow
* Updated all user lookups and account creation logic to use normalized email values consistently

## Why this change?

Previously, email normalization was applied only in the registration flow, while other authentication methods used raw email values. This could lead to inconsistent authentication behavior when emails contained leading/trailing whitespace or different casing.

By centralizing email normalization, all authentication flows now treat logically identical email addresses consistently.

## Benefits

* Prevents login failures caused by whitespace or casing differences
* Ensures consistent user lookup across all authentication methods
* Reduces ambiguity around duplicate account handling
* Improves maintainability by centralizing email normalization logic
* Keeps authentication behavior consistent regardless of the authentication provider

## Testing

* Registered a new account using mixed-case and whitespace-padded email addresses
* Verified login succeeds using differently cased email input
* Verified Google authentication uses normalized email values
* Verified GitHub authentication uses normalized email values
* Confirmed existing authentication functionality remains unchanged

## Issue

Closes #358
