### PR TITLE
fix(tips): handle Redis cache write failures gracefully

### DIFF
--- a/back-end/src/controllers/tipController.js
+++ b/back-end/src/controllers/tipController.js
@@ -34,8 +34,24 @@ const getDailyTip = async (req, res, next) => {
         category: "General",
       };
       // Cache the fallback for the day to avoid repeated DB checks
-      await redis.setex(cacheKey, getSecondsUntilMidnight(), JSON.stringify(fallback));
-      return response.success(res, fallback, 'Daily tip (fallback)');
+      try {
+        await redis.setex(
+          cacheKey,
+          getSecondsUntilMidnight(),
+          JSON.stringify(fallback)
+        );
+      } catch (redisErr) {
+        console.warn(
+          "Failed to cache fallback daily tip:",
+          redisErr.message
+        );
+      }
+
+      return response.success(
+        res,
+        fallback,
+        "Daily tip (fallback)"
+      );
     }
 
     // 3. Deterministic selection based on the date


### PR DESCRIPTION
## Summary

This PR improves the resilience of the daily tip endpoint by isolating Redis cache write failures from the main response flow.

## Changes made

* Wrapped Redis cache write operations in a dedicated `try/catch` block
* Logged cache write failures instead of allowing them to fail the request
* Ensured the resolved daily tip response is returned even when Redis is unavailable
* Preserved the existing caching behavior when Redis writes succeed

## Why this change?

Previously, the endpoint could fail if Redis encountered an error while writing the daily tip to the cache, even though a valid tip had already been retrieved from the database or fallback logic.

Since Redis is used only as a cache, cache write failures should not prevent successful responses from being returned to clients.

## Benefits

* Makes the daily tip endpoint resilient to Redis write failures
* Prevents unnecessary `500 Internal Server Error` responses
* Keeps Redis as a performance optimization instead of a hard dependency
* Improves graceful degradation during Redis outages or transient cache failures

## Testing

* Verified the endpoint returns the daily tip when Redis writes succeed
* Simulated Redis write failures and confirmed the endpoint still returns a successful response
* Verified cache write failures are logged without affecting API behavior
* Confirmed existing cache hit behavior remains unchanged

## Issue

Closes #364
