### PR TITLE
fix(upload): enforce server-side audio file size limits

### DIFF
--- a/back-end/src/controllers/uploadController.js
+++ b/back-end/src/controllers/uploadController.js
@@ -6,6 +6,14 @@ const uploadAudio = async (req, res, next) => {
       return res.status(400).json({ error: 'No audio file provided' });
     }
 
+    const MAX_AUDIO_SIZE = 10 * 1024 * 1024;
+
+    if (req.file.size > MAX_AUDIO_SIZE) {
+      return res.status(413).json({
+        error: 'File size exceeds 10MB limit.',
+      });
+    }
+
     const { buffer, originalname, mimetype } = req.file;
 
     if (!['audio/webm', 'video/webm', 'audio/mp4', 'video/mp4'].includes(mimetype)) {


### PR DESCRIPTION
## Summary

This PR adds server-side file size validation for audio uploads to prevent oversized files from reaching the S3 upload flow.

## Changes made

* Configured Multer with a maximum allowed audio file size
* Added controller-level validation for uploaded audio file size before calling the S3 upload helper
* Returned a consistent `413 Payload Too Large` response for oversized uploads
* Prevented oversized files from being processed or uploaded to S3

## Why this change?

Previously, the upload flow validated that an uploaded file existed and was an audio file, but it did not enforce a maximum file size before initiating the S3 upload.

This allowed very large uploads to consume server resources and bandwidth before eventually failing or completing unnecessarily.

## Benefits

* Rejects oversized audio files early in the request lifecycle
* Prevents unnecessary uploads to S3
* Reduces memory, bandwidth, and storage usage
* Improves resilience against accidental or abusive oversized uploads
* Returns clearer validation errors for clients

## Testing

* Verified valid audio files upload successfully
* Verified oversized audio files return `413 Payload Too Large`
* Confirmed oversized files are not forwarded to the S3 upload helper
* Verified existing upload behavior remains unchanged for valid files

## Issue

Closes #365
