### PR TITLE
fix(user): remove fallback email JWT secret

### DIFF
--- a/back-end/src/config/jwt.js
+++ b/back-end/src/config/jwt.js
@@ -1,0 +1,11 @@
+const jwtEmailSecret = process.env.JWT_EMAIL_SECRET;
+
+if (!jwtEmailSecret) {
+  throw new Error(
+    "JWT_EMAIL_SECRET environment variable must be defined"
+  );
+}
+
+module.exports = {
+  jwtEmailSecret,
+};

--- a/back-end/src/controllers/userController.js
+++ b/back-end/src/controllers/userController.js
@@ -3,6 +3,7 @@ const { validationResult } = require('express-validator');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { Op } = require('sequelize');
+const { jwtEmailSecret } = require("../config/jwt");
 
 // ==================== CONFIGURATION ====================
 const BCRYPT_ROUNDS = 12;
@@ -269,8 +270,8 @@ exports.changeEmail = async (req, res, next) => {
     // Generate verification token
     const verificationToken = jwt.sign(
       { userId: id, newEmail },
-      process.env.JWT_EMAIL_SECRET || 'email-secret-key',
-      { expiresIn: '24h' }
+      jwtEmailSecret,
+      { expiresIn: "24h" }
     );
 
     // Store pending email change
@@ -307,7 +308,7 @@ exports.verifyEmailChange = async (req, res, next) => {
     // Verify token
     const decoded = jwt.verify(
       token,
-      process.env.JWT_EMAIL_SECRET || 'email-secret-key'
+      jwtEmailSecret
     );
     const { userId, newEmail } = decoded;
 


### PR DESCRIPTION
## Summary

This PR removes the insecure fallback JWT secret used for email change verification and introduces centralized configuration for the email verification JWT secret.

## Changes made

* Removed the hardcoded fallback secret from email verification token signing
* Removed the hardcoded fallback secret from email verification token verification
* Added centralized configuration for `JWT_EMAIL_SECRET`
* Ensured the application fails fast when `JWT_EMAIL_SECRET` is not configured
* Updated the user controller to use the validated configuration value instead of reading an optional environment variable inline

## Why this change?

Previously, the email change flow used a hardcoded fallback secret when `JWT_EMAIL_SECRET` was missing. This allowed the application to continue operating with a predictable secret, weakening the security of email verification tokens and masking configuration errors.

By requiring a validated secret at startup, email verification tokens are now signed and verified only with a properly configured secret.

## Benefits

* Removes a predictable fallback secret from a security-sensitive flow
* Prevents insecure token generation when environment variables are misconfigured
* Encourages centralized configuration management
* Makes configuration errors fail fast instead of silently weakening security
* Improves maintainability by avoiding repeated environment variable lookups

## Testing

* Verified email change requests generate valid verification tokens when `JWT_EMAIL_SECRET` is configured
* Verified email verification succeeds with valid tokens
* Confirmed the application fails to start when `JWT_EMAIL_SECRET` is missing
* Confirmed no changes to the existing API behavior when configuration is valid

## Issue

Closes #366
